### PR TITLE
feat: add browser original image download with @ modifier stripping

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -129,15 +129,20 @@ python -m src
 
 依赖 PyInstaller 6.0+。
 
+> **⚠️ 注意**: PyInstaller **不支持交叉编译**。`--windows` 参数只能在 Windows 系统上使用，`--linux` 参数只能在 Linux 系统上使用。
+> 如需在 Linux 上构建 Windows 安装包，请使用 [GitHub Actions](#ci-github-actions)（推送到 `main` 分支自动触发，或手动运行 workflow）。
+
 ```bash
 pip install pyinstaller
 
 # 自动检测当前系统打包
 python scripts/build.py
 
-# 指定目标系统
-python scripts/build.py --windows          # Windows 目标
-python scripts/build.py --linux            # Linux 目标
+# Windows 目标（仅在 Windows 上运行）
+python scripts/build.py --windows
+
+# Linux 目标（仅在 Linux 上运行）
+python scripts/build.py --linux
 
 # 仅打包，跳过安装包
 python scripts/build.py --build-only

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -53,6 +53,10 @@ _MSGS = {
         "zh": "错误: --installer-only 不支持当前目标 %s",
         "en": "ERROR: --installer-only not supported for target %s",
     },
+    "cross_compile_not_supported": {
+        "zh": "错误: PyInstaller 不支持交叉编译，在 Linux 上无法生成 Windows 可执行文件。\n      请使用 GitHub Actions（推送到 main 或手动触发 workflow）或在 Windows 机器上运行此脚本。",
+        "en": "ERROR: PyInstaller does not support cross-compilation. Cannot produce a Windows executable from Linux.\n       Use GitHub Actions (push to main or trigger workflow_dispatch) or run this script on a Windows machine.",
+    },
 }
 
 _lang = "zh"
@@ -286,6 +290,9 @@ if __name__ == "__main__":
         _set_lang("zh")
 
     if args.target_windows:
+        if not IS_WINDOWS:
+            print(L("cross_compile_not_supported"))
+            sys.exit(1)
         target = "Windows"
     elif args.target_linux:
         target = "Linux"

--- a/src/config.py
+++ b/src/config.py
@@ -95,6 +95,8 @@ class Config:
         "window_x": -1,
         "window_y": -1,
         "auto_play_gif": True,
+        # 图片来源 (DeepSeek V4 Flash)
+        "try_original_image": False,
     }
 
     def __init__(self, path: Path = None):

--- a/src/main.py
+++ b/src/main.py
@@ -46,7 +46,7 @@ class OhMyMemeApp:
         # 2. 注册全局快捷键
         self._register_hotkey()
 
-        # 3. 启动系统托盘 (DeepSeek V4 Flash: Linux 下跳过 GTK 线程冲突)
+        # 3. 启动系统托盘 (DeepSeek V4 Flash)
         if platform.system() == "Linux":
             logger.warning("Linux 环境：跳过系统托盘（GTK 线程冲突）")
         else:

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import platform  # DeepSeek V4 Flash
 import signal
 import subprocess
 import sys
@@ -46,9 +47,9 @@ class OhMyMemeApp:
         # 2. 注册全局快捷键
         self._register_hotkey()
 
-        # 3. 启动系统托盘（WSL 环境下跳过，避免 GTK 线程冲突）
-        if is_wsl():
-            logger.warning("WSL 环境：跳过系统托盘（缺少 DBus，存在 GTK 线程冲突）")
+        # 3. 启动系统托盘 (DeepSeek V4 Flash: Linux 下跳过 GTK 线程冲突)
+        if platform.system() == "Linux":
+            logger.warning("Linux 环境：跳过系统托盘（GTK 线程冲突）")
         else:
             self._tray = TrayManager(
                 on_show=self._on_hotkey,

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,6 @@ from .hotkey import GlobalHotkey
 from .platform_util import (
     _startup_folder_path,
     is_auto_start_enabled,
-    is_wsl,
     set_auto_start,
 )
 from .tray import TrayManager

--- a/src/tray.py
+++ b/src/tray.py
@@ -79,7 +79,7 @@ class TrayManager:
             logger.error("Cannot create tray icon (PIL missing)")
             return False
 
-        # DeepSeek V4 Flash: 原中文字符 latin-1 编码崩溃，改为 ASCII
+        # DeepSeek V4 Flash
         dev_tag = " (dev)" if self._source_mode else ""
         title = "OhMyMeme" + dev_tag
         menu_items = []

--- a/src/tray.py
+++ b/src/tray.py
@@ -79,17 +79,19 @@ class TrayManager:
             logger.error("Cannot create tray icon (PIL missing)")
             return False
 
-        dev_tag = "（本地开发）" if self._source_mode else ""
+        dev_tag = " (dev)" if self._source_mode else ""  # DeepSeek V4 Flash: 原中文字符 latin-1 编码崩溃
         title = "OhMyMeme" + dev_tag
         menu_items = []
         if self._source_mode:
-            menu_items.append(pystray.MenuItem(dev_tag, lambda: None, enabled=False))
+            menu_items.append(
+                pystray.MenuItem("OhMyMeme (dev)", lambda: None, enabled=False)
+            )
         menu_items += [
             pystray.MenuItem(
-                "显示/隐藏", self._on_show or (lambda: None), default=True
+                "Show/Hide", self._on_show or (lambda: None), default=True
             ),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem("退出", self._on_quit or (lambda: None)),
+            pystray.MenuItem("Quit", self._on_quit or (lambda: None)),
         ]
         menu = pystray.Menu(*menu_items)
 

--- a/src/tray.py
+++ b/src/tray.py
@@ -79,7 +79,8 @@ class TrayManager:
             logger.error("Cannot create tray icon (PIL missing)")
             return False
 
-        dev_tag = " (dev)" if self._source_mode else ""  # DeepSeek V4 Flash: 原中文字符 latin-1 编码崩溃
+        # DeepSeek V4 Flash: 原中文字符 latin-1 编码崩溃，改为 ASCII
+        dev_tag = " (dev)" if self._source_mode else ""
         title = "OhMyMeme" + dev_tag
         menu_items = []
         if self._source_mode:

--- a/src/webui.py
+++ b/src/webui.py
@@ -65,7 +65,14 @@ def _strip_url_modifiers(url: str) -> str:
     else:
         clean_path = parsed.path
     return urlunparse(
-        (parsed.scheme, parsed.netloc, clean_path, parsed.params, parsed.query, parsed.fragment)
+        (
+            parsed.scheme,
+            parsed.netloc,
+            clean_path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
     )
 
 
@@ -378,8 +385,8 @@ class JsApi:
         clean_url = _strip_url_modifiers(url)
         import shutil
         import tempfile
-        from urllib.request import urlopen
         from urllib.error import URLError
+        from urllib.request import urlopen
 
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".tmp")
         tmp_path = tmp.name
@@ -389,7 +396,9 @@ class JsApi:
                 with open(tmp_path, "wb") as f:
                     shutil.copyfileobj(resp, f)
             ids = self._webui._do_import([tmp_path])
-            return {"ok": True, "id": ids[0]} if ids else {"ok": False, "error": "导入失败"}
+            if ids:
+                return {"ok": True, "id": ids[0]}
+            return {"ok": False, "error": "导入失败"}
         except URLError as e:
             return {"ok": False, "error": f"下载失败: {e.reason}"}
         except Exception as e:
@@ -531,7 +540,8 @@ class JsApi:
         return {
             "hotkey": d.get("hotkey", "Ctrl+Alt+N"),
             "auto_play_gif": d.get("auto_play_gif", True),
-            "try_original_image": d.get("try_original_image", False),  # DeepSeek V4 Flash
+            # DeepSeek V4 Flash
+            "try_original_image": d.get("try_original_image", False),
             "auto_start": is_auto_start_enabled(),
             "silent_start": d.get("silent_start", False),
             "sync_auto_fetch_index": d.get("sync_auto_fetch_index", False),
@@ -650,7 +660,8 @@ class SettingsApi:
         return {
             "hotkey": d.get("hotkey", "Ctrl+Alt+N"),
             "auto_play_gif": d.get("auto_play_gif", True),
-            "try_original_image": d.get("try_original_image", False),  # DeepSeek V4 Flash
+            # DeepSeek V4 Flash
+            "try_original_image": d.get("try_original_image", False),
             "auto_start": is_auto_start_enabled(),
             "silent_start": d.get("silent_start", False),
             "sync_auto_fetch_index": d.get("sync_auto_fetch_index", False),

--- a/src/webui.py
+++ b/src/webui.py
@@ -52,6 +52,39 @@ logger = logging.getLogger(__name__)
 
 HTML_DIR = Path(__file__).resolve().parent / "webui"
 
+# ─── 工具函数 (DeepSeek V4 Flash) ───
+
+
+def _strip_url_modifiers(url: str) -> str:
+    """去掉图片 URL 中的 @ 修饰参数，返回原图 URL"""
+    from urllib.parse import urlparse, urlunparse
+
+    parsed = urlparse(url)
+    if "@" in parsed.path:
+        clean_path = parsed.path[: parsed.path.index("@")]
+    else:
+        clean_path = parsed.path
+    return urlunparse(
+        (parsed.scheme, parsed.netloc, clean_path, parsed.params, parsed.query, parsed.fragment)
+    )
+
+
+def _check_connectivity() -> dict:  # DeepSeek V4 Flash
+    """检查互联网连接，返回 {ok, latency}"""
+    import socket as _socket
+
+    hosts = [("baidu.com", 80), ("www.baidu.com", 443)]
+    for host, port in hosts:
+        try:
+            t0 = time.time()
+            s = _socket.create_connection((host, port), timeout=3)
+            s.close()
+            latency = int((time.time() - t0) * 1000)
+            return {"ok": True, "latency": f"{latency}ms"}
+        except Exception:
+            continue
+    return {"ok": False, "latency": ""}
+
 
 class JsApi:
     """暴露给前端的 JS API"""
@@ -332,6 +365,41 @@ class JsApi:
         ok = updater.run_installer(path)
         return {"ok": ok, "error": "" if ok else "run installer failed"}
 
+    def check_connectivity(self) -> dict:  # DeepSeek V4 Flash
+        return _check_connectivity()
+
+    def download_original_image(self, url: str) -> dict:  # DeepSeek V4 Flash
+        """下载浏览器来源的原始图片（去掉 @ 修饰），导入到缓存"""
+        if not self._cfg.get("try_original_image", False):
+            return {"ok": False, "error": "功能未启用"}
+        conn = _check_connectivity()
+        if not conn["ok"]:
+            return {"ok": False, "error": "无网络连接"}
+        clean_url = _strip_url_modifiers(url)
+        import shutil
+        import tempfile
+        from urllib.request import urlopen
+        from urllib.error import URLError
+
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".tmp")
+        tmp_path = tmp.name
+        tmp.close()
+        try:
+            with urlopen(clean_url, timeout=15) as resp:
+                with open(tmp_path, "wb") as f:
+                    shutil.copyfileobj(resp, f)
+            ids = self._webui._do_import([tmp_path])
+            return {"ok": True, "id": ids[0]} if ids else {"ok": False, "error": "导入失败"}
+        except URLError as e:
+            return {"ok": False, "error": f"下载失败: {e.reason}"}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+
     def get_sync_progress(self) -> dict:
         return sync_module.get_sync_progress()
 
@@ -463,6 +531,7 @@ class JsApi:
         return {
             "hotkey": d.get("hotkey", "Ctrl+Alt+N"),
             "auto_play_gif": d.get("auto_play_gif", True),
+            "try_original_image": d.get("try_original_image", False),  # DeepSeek V4 Flash
             "auto_start": is_auto_start_enabled(),
             "silent_start": d.get("silent_start", False),
             "sync_auto_fetch_index": d.get("sync_auto_fetch_index", False),
@@ -571,6 +640,9 @@ class SettingsApi:
         self._webui = webui
         self._cfg = get_config()
 
+    def check_connectivity(self) -> dict:  # DeepSeek V4 Flash
+        return _check_connectivity()
+
     def get_settings(self) -> dict:
         d = self._cfg.to_dict()
         from .platform_util import is_auto_start_enabled
@@ -578,6 +650,7 @@ class SettingsApi:
         return {
             "hotkey": d.get("hotkey", "Ctrl+Alt+N"),
             "auto_play_gif": d.get("auto_play_gif", True),
+            "try_original_image": d.get("try_original_image", False),  # DeepSeek V4 Flash
             "auto_start": is_auto_start_enabled(),
             "silent_start": d.get("silent_start", False),
             "sync_auto_fetch_index": d.get("sync_auto_fetch_index", False),
@@ -1253,7 +1326,9 @@ class WebUI:
 
         self._started = True
         # start() blocks - 在调用线程运行 GUI 循环
-        webview.start(debug=False, http_server=False)
+        # DeepSeek V4 Flash: Linux 强制 GTK 后端（Qt WebEngine Wayland 下崩溃）
+        gui = "gtk" if platform.system() == "Linux" else None
+        webview.start(debug=False, http_server=False, gui=gui)
         return True
 
     def open_settings(self):

--- a/src/webui.py
+++ b/src/webui.py
@@ -1337,7 +1337,7 @@ class WebUI:
 
         self._started = True
         # start() blocks - 在调用线程运行 GUI 循环
-        # DeepSeek V4 Flash: Linux 强制 GTK 后端（Qt WebEngine Wayland 下崩溃）
+        # DeepSeek V4 Flash
         gui = "gtk" if platform.system() == "Linux" else None
         webview.start(debug=False, http_server=False, gui=gui)
         return True

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -1151,7 +1151,7 @@ function openSettings() { try { pywebview.api.open_settings(); } catch(e) {} }
     e.preventDefault();
     dragCounter = 0;
     overlay.classList.remove('drag-over');
-    // DeepSeek V4 Flash: 尝试通过 URL 获取原图（从浏览器拖入时有 text/uri-list）
+    // DeepSeek V4 Flash
     let uri = '';
     try {
       const types = e.dataTransfer.types;

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -1151,6 +1151,24 @@ function openSettings() { try { pywebview.api.open_settings(); } catch(e) {} }
     e.preventDefault();
     dragCounter = 0;
     overlay.classList.remove('drag-over');
+    // DeepSeek V4 Flash: 尝试通过 URL 获取原图（从浏览器拖入时有 text/uri-list）
+    let uri = '';
+    try {
+      const types = e.dataTransfer.types;
+      if (types && types.includes && types.includes('text/uri-list')) {
+        uri = e.dataTransfer.getData('text/uri-list');
+      }
+    } catch(_) {}
+    if (uri) {
+      try {
+        const r = await api('download_original_image', uri);
+        if (r && r.ok) {
+          location.reload();
+          return;
+        }
+      } catch(_) {}
+    }
+    // 回退：文件 base64 上传
     const files = e.dataTransfer.files;
     if (!files || files.length === 0) return;
     const imgExts = /\.(png|jpg|jpeg|gif|webp|bmp)$/i;

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -191,6 +191,15 @@ select:hover { border-color: var(--border-light); }
     </div>
 
     <div class="section">
+      <!-- DeepSeek V4 Flash -->
+      <div class="section-title">图片来源</div>
+      <label class="check-row">
+        <input id="s-try-original" type="checkbox" onchange="checkConnectivity()">浏览器来源尝试获取原图
+      </label>
+      <div id="s-net-status" style="font-size:12px;margin-top:4px;padding-left:4px;color:var(--muted)"></div>
+    </div>
+
+    <div class="section">
       <div class="section-title">从手机导入</div>
       <p style="font-size:11.5px;color:var(--muted);margin-bottom:10px;line-height:1.6">通过 ADB 从连接的 Android 手机拉取 QQ 表情包缓存并打包 ZIP</p>
       <div style="display:flex;gap:8px">
@@ -462,6 +471,26 @@ function toggleSilentStart() {
   if (row) row.style.display = autoStart ? '' : 'none';
 }
 
+async function checkConnectivity() {  // DeepSeek V4 Flash
+  const el = document.getElementById('s-net-status');
+  if (!el) return;
+  el.textContent = '正在检查网络...';
+  el.style.color = 'var(--muted)';
+  try {
+    const r = await api('check_connectivity');
+    if (r && r.ok) {
+      el.innerHTML = '● 已连接 <span style="opacity:.6">(' + (r.latency || '') + ')</span>';
+      el.style.color = '#4caf50';
+    } else {
+      el.textContent = '● 无网络连接';
+      el.style.color = '#f44336';
+    }
+  } catch(_) {
+    el.textContent = '● 检查失败';
+    el.style.color = '#f44336';
+  }
+}
+
 /* Load settings */
 async function getSettings() {
   const s = await api('get_settings');
@@ -472,6 +501,8 @@ async function getSettings() {
   const ss = document.getElementById('s-silent-start');
   if (hk && s.hotkey) hk.value = s.hotkey;
   if (gif) gif.checked = s.auto_play_gif !== false;
+  const to = document.getElementById('s-try-original');
+  if (to) to.checked = s.try_original_image === true;  // DeepSeek V4 Flash
   if (as) as.checked = s.auto_start === true;
   if (ss) ss.checked = s.silent_start === true;
   toggleSilentStart();
@@ -511,6 +542,7 @@ async function getSettings() {
   if (ud) ud.checked = s.show_upload_done !== false;
   if (dp) dp.checked = s.show_download_progress !== false;
   if (dd) dd.checked = s.show_download_done !== false;
+  checkConnectivity();  // DeepSeek V4 Flash
   return true;
 }
 
@@ -593,12 +625,14 @@ function validateSync(sync) {
 async function saveSettings() {
   const hotkey = document.getElementById('s-hotkey')?.value || 'Ctrl+Alt+N';
   const gif = document.getElementById('s-gif')?.checked !== false;
+  const try_original = document.getElementById('s-try-original')?.checked === true;  // DeepSeek V4 Flash
   const auto_start = document.getElementById('s-auto-start')?.checked === true;
   const silent_start = document.getElementById('s-silent-start')?.checked === true;
   const sync = collectSyncSettings();
   if (!validateSync(sync)) return;
   await api('save_settings', {
     hotkey, auto_play_gif: gif,
+    try_original_image: try_original,  // DeepSeek V4 Flash
     auto_start, silent_start,
     ...sync
   });
@@ -614,9 +648,12 @@ async function resetSettings() {
     const ss = document.getElementById('s-silent-start');
     if (hk) hk.value = s.hotkey;
     if (gif) gif.checked = s.auto_play_gif !== false;
+    const to = document.getElementById('s-try-original');  // DeepSeek V4 Flash
+    if (to) to.checked = false;
     if (as) as.checked = s.auto_start === true;
     if (ss) ss.checked = s.silent_start === true;
     toggleSilentStart();
+    checkConnectivity();  // DeepSeek V4 Flash
     const ff = document.getElementById('s-sync-fetch');
     const sa = document.getElementById('s-sync-auto');
     const st = document.getElementById('s-sync-type');


### PR DESCRIPTION

- Add "try_original_image" config toggle, connectivity check,
  and download_original_image JsApi for browser drag-and-drop
- fix: replace Chinese tray strings with ASCII to avoid
  latin-1 encoding crash on Linux
- fix: skip pystray on Linux to resolve GTK thread conflict
- fix: force GTK backend on Linux to prevent Qt Wayland crash

The existence of **second commitment** is due to the lint + format tests

Generated by **DeepSeek V4 Flash**

@TNTXZ 