### PR TITLE
fix: 修复 Windows 打包版 ADB 路径拼接错误

### DIFF
--- a/src/adb_util.py
+++ b/src/adb_util.py
@@ -77,7 +77,7 @@ def get_qq_progress() -> dict:
 
 def _get_adb_dir() -> Path:
     if getattr(sys, "frozen", False):
-        base = os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local")
+        base =Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))  
         return base / "OhMyMeme" / ".adb"
     return Path(__file__).parent.parent / ".adb"
 


### PR DESCRIPTION
## Summary

Fixes #4.

修复 Windows 打包版中 ADB 目录路径拼接导致的崩溃问题。

## Cause

Windows 下 `os.environ.get("LOCALAPPDATA")` 返回的是字符串，原代码直接使用 `/` 拼接路径，导致 `str / str` 报错。

## Changes

- 将 `LOCALAPPDATA` 的返回值转换为 `Path`
- 保持 `_get_adb_dir()` 返回 `Path`
- 修复 `--debug-adb` 启动崩溃问题

## Testing

已在 Windows 11 下验证：

- exe 可以正常启动
- `--debug-adb` 不再崩溃
- ADB 目录路径可以正常解析