### PR TITLE
fix: correct file extension and base64 encoding when dragging images from browser

### DIFF
--- a/src/webui.py
+++ b/src/webui.py
@@ -386,16 +386,40 @@ class JsApi:
         import shutil
         import tempfile
         from urllib.error import URLError
+        from urllib.parse import urlparse
         from urllib.request import urlopen
 
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".tmp")
+        # 从 URL 路径推断扩展名
+        parsed_path = urlparse(clean_url).path
+        _, ext = os.path.splitext(parsed_path)
+        ext = ext.lower() if ext else ""
+        allowed_img_ext = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+
+        # URL 路径无扩展名时，从响应 Content-Type 推断
+        need_type = not ext or ext not in allowed_img_ext
+
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".download")
         tmp_path = tmp.name
         tmp.close()
         try:
             with urlopen(clean_url, timeout=15) as resp:
+                if need_type:
+                    ct = resp.headers.get("Content-Type", "")
+                    content_type = ct.split(";")[0].strip()
+                    type_map = {
+                        "image/gif": ".gif",
+                        "image/png": ".png",
+                        "image/jpeg": ".jpg",
+                        "image/webp": ".webp",
+                        "image/bmp": ".bmp",
+                    }
+                    ext = type_map.get(content_type, ".png")
                 with open(tmp_path, "wb") as f:
                     shutil.copyfileobj(resp, f)
-            ids = self._webui._do_import([tmp_path])
+            # 重命名为正确扩展名
+            final_path = tmp_path + ext
+            os.rename(tmp_path, final_path)
+            ids = self._webui._do_import([final_path])
             if ids:
                 return {"ok": True, "id": ids[0]}
             return {"ok": False, "error": "导入失败"}
@@ -406,6 +430,10 @@ class JsApi:
         finally:
             try:
                 os.unlink(tmp_path)
+            except Exception:
+                pass
+            try:
+                os.unlink(tmp_path + ext)
             except Exception:
                 pass
 

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -1175,8 +1175,12 @@ function openSettings() { try { pywebview.api.open_settings(); } catch(e) {} }
     for (const file of files) {
       if (!imgExts.test(file.name)) continue;
       try {
-        const ab = await file.arrayBuffer();
-        const b64 = btoa(new Uint8Array(ab).reduce((s, b) => s + String.fromCharCode(b), ''));
+        const b64 = await new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result.split(',')[1]);
+          reader.onerror = () => reject(reader.error);
+          reader.readAsDataURL(file);
+        });
         items.push({ name: file.name, data: b64 });
       } catch(_) {}
     }


### PR DESCRIPTION
**背景**
从浏览器拖入 GIF/WebP 等图片时，存在两个问题：

[download_original_image](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 丢失扩展名：下载到 [suffix=".tmp"](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 的临时文件后直接传给 [_do_import](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html)，导致文件被存为 [{hash}.tmp](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html)、mime_type = "image/tmp"。前端无法识别为 GIF，只能显示首帧静态缩略图。
前端 base64 编码低效：arrayBuffer() + reduce 逐字符拼接字符串，大图片 O(n²) 内存开销。


**变更**
[webui.py](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) — [download_original_image](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 正确推断扩展名

优先从 URL 路径（[os.path.splitext](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html)）取扩展名
路径无扩展名时，回退到 HTTP 响应头 Content-Type 映射（gif/png/jpeg/webp/bmp）
临时文件改用 .download 后缀，确定扩展名后 [os.rename](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 为重命名后再导入
[index.html](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) — 前端 base64 编码优化

用 FileReader.readAsDataURL 替代 arrayBuffer + reduce + btoa，浏览器原生处理编码，无中间字符串膨胀


**测试**
[ruff check](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) + [black --check](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 全部通过

@TNTXZ 

已在linux上测试过，正常工作