### PR TITLE
feat(webp): support animated WebP storage and clipboard conversion

### DIFF
--- a/src/clipboard_util.py
+++ b/src/clipboard_util.py
@@ -4,6 +4,7 @@ import io
 import logging
 import os
 import struct
+import tempfile
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,59 @@ try:
     HAS_PYPERCLIP = True
 except ImportError:
     HAS_PYPERCLIP = False
+
+
+def _is_animated(path: str) -> bool:
+    """检测文件是否为动图（GIF / WebP）"""
+    try:
+        with open(path, "rb") as f:
+            header = f.read(50)
+        # GIF89a 一般为动图
+        if header[:6] == b"GIF89a":
+            return True
+        # WebP: ANIM chunk 在 VP8X 之后（约偏移 30+），扫描整个头
+        if header[:4] == b"RIFF" and header[8:12] == b"WEBP":
+            return b"ANIM" in header
+        return False
+    except Exception:
+        return False
+
+
+def _webp_to_gif(webp_path):
+    """WebP 动图转临时 GIF，返回路径，调用方负责清理"""
+    if not HAS_PIL:
+        return None
+    try:
+        img = PILImage.open(webp_path)
+        if not getattr(img, "is_animated", False):
+            return None
+        # 收集所有帧
+        frames, durations = [], []
+        try:
+            while True:
+                frames.append(img.copy())
+                durations.append(img.info.get("duration", 100))
+                img.seek(img.tell() + 1)
+        except EOFError:
+            pass
+        if not frames:
+            return None
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".gif")
+        tmp_path = tmp.name
+        tmp.close()
+        frames[0].save(
+            tmp_path,
+            format="GIF",
+            save_all=True,
+            append_images=frames[1:],
+            duration=durations,
+            loop=0,
+        )
+        img.close()
+        return tmp_path
+    except Exception as e:
+        logger.warning(f"_webp_to_gif: {e}")
+        return None
 
 
 def copy_image_to_clipboard(image_path: str) -> bool:
@@ -48,6 +102,18 @@ def _copy_image_windows(image_path: str, ext: str) -> bool:
     if ext == ".gif":
         if _copy_gif_windows(image_path):
             return True
+
+    # WebP 动图：转 GIF 后走动画路径
+    if ext == ".webp" and _is_animated(image_path):
+        gif_path = _webp_to_gif(image_path)
+        if gif_path:
+            ok = _copy_gif_windows(gif_path)
+            try:
+                os.unlink(gif_path)
+            except Exception:
+                pass
+            if ok:
+                return True
 
     if HAS_PIL:
         try:
@@ -331,10 +397,12 @@ def _copy_image_linux(image_path: str, ext: str) -> bool:
         import subprocess
 
         abs_path = os.path.abspath(image_path)
+        # 动图（GIF / WebP 动图）用 image/gif MIME
+        mime = "image/gif" if _is_animated(image_path) else "image/png"
         # 尝试 xclip
         try:
             subprocess.run(
-                ["xclip", "-selection", "clipboard", "-t", "image/png", "-i", abs_path],
+                ["xclip", "-selection", "clipboard", "-t", mime, "-i", abs_path],
                 capture_output=True,
                 timeout=5,
                 check=True,
@@ -345,7 +413,7 @@ def _copy_image_linux(image_path: str, ext: str) -> bool:
         # 尝试 wl-copy (Wayland)
         try:
             subprocess.run(
-                ["wl-copy", "--type", "image/png", "-i", abs_path],
+                ["wl-copy", "--type", mime, "-i", abs_path],
                 capture_output=True,
                 timeout=5,
                 check=True,

--- a/src/clipboard_util.py
+++ b/src/clipboard_util.py
@@ -4,7 +4,6 @@ import io
 import logging
 import os
 import struct
-import tempfile
 
 logger = logging.getLogger(__name__)
 
@@ -40,37 +39,54 @@ def _is_animated(path: str) -> bool:
 
 
 def _webp_to_gif(webp_path):
-    """WebP 动图转临时 GIF，返回路径，调用方负责清理"""
+    """WebP 动图转 GIF，存入缓存（同 WebP 目录），返回路径"""
     if not HAS_PIL:
         return None
     try:
+        # 目标路径：同目录下同名 .gif，持久存在
+        gif_path = os.path.splitext(webp_path)[0] + ".gif"
+        if os.path.isfile(gif_path):
+            return gif_path
         img = PILImage.open(webp_path)
         if not getattr(img, "is_animated", False):
+            img.close()
             return None
         # 收集所有帧
         frames, durations = [], []
         try:
             while True:
                 frames.append(img.copy())
-                durations.append(img.info.get("duration", 100))
+                d = img.info.get("duration", 100) or 100
+                if d < 50:
+                    d = 100
+                durations.append(d)
                 img.seek(img.tell() + 1)
         except EOFError:
             pass
+        img.close()
         if not frames:
             return None
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".gif")
-        tmp_path = tmp.name
-        tmp.close()
+        # 统一量化到 256 色调色板
+        for i, f in enumerate(frames):
+            mode = f.mode
+            if mode in ("RGBA", "PA"):
+                if mode == "PA":
+                    f = f.convert("RGBA")
+                # PIL 内建量化：alpha ≤ 128 变透明，> 128 变不透明
+                # 边缘用 Floyd-Steinberg 抖动模拟平滑过渡
+                # 全透明区域 (alpha=0) 保持为 GIF 透明色
+                frames[i] = f.quantize(colors=256)
+            elif mode not in ("P",):
+                frames[i] = f.quantize(colors=256)
         frames[0].save(
-            tmp_path,
+            gif_path,
             format="GIF",
             save_all=True,
             append_images=frames[1:],
             duration=durations,
             loop=0,
         )
-        img.close()
-        return tmp_path
+        return gif_path
     except Exception as e:
         logger.warning(f"_webp_to_gif: {e}")
         return None
@@ -106,14 +122,8 @@ def _copy_image_windows(image_path: str, ext: str) -> bool:
     # WebP 动图：转 GIF 后走动画路径
     if ext == ".webp" and _is_animated(image_path):
         gif_path = _webp_to_gif(image_path)
-        if gif_path:
-            ok = _copy_gif_windows(gif_path)
-            try:
-                os.unlink(gif_path)
-            except Exception:
-                pass
-            if ok:
-                return True
+        if gif_path and _copy_gif_windows(gif_path):
+            return True
 
     if HAS_PIL:
         try:

--- a/src/webui.py
+++ b/src/webui.py
@@ -1347,6 +1347,10 @@ class WebUI:
                 fpath = os.path.join(root, fname)
                 if "thumbnails" in fpath:
                     continue
+                # 跳过由 WebP 动图自动生成的 GIF（同名 .webp 存在即为生成物）
+                stem = os.path.splitext(fname)[0]
+                if ext == ".gif" and os.path.isfile(os.path.join(root, stem + ".webp")):
+                    continue
                 if db.get_by_filename(fname):
                     continue
                 try:

--- a/src/webui.py
+++ b/src/webui.py
@@ -43,7 +43,7 @@ except ImportError:
 
 from . import adb_util, updater
 from . import sync as sync_module
-from .clipboard_util import copy_image_to_clipboard
+from .clipboard_util import _is_animated, copy_image_to_clipboard
 from .config import get_config
 from .database import get_db
 from .manifest import build as build_manifest
@@ -129,9 +129,16 @@ class JsApi:
         auto_gif = self._cfg.get("auto_play_gif", True)
         result = []
         for r in rows:
-            is_gif = r.get("mime_type", "").endswith("gif") or r[
-                "filename"
-            ].lower().endswith(".gif")
+            fname = r["filename"].lower()
+            is_gif = r.get("mime_type", "").endswith("gif") or fname.endswith(".gif")
+            # 动画检测：GIF 或 WebP 动图
+            if is_gif:
+                is_animated = True
+            elif fname.endswith(".webp"):
+                path = self._find_meme_file(r["filename"])
+                is_animated = _is_animated(path) if path else False
+            else:
+                is_animated = False
             oname = r.get("original_name", "")
             if not oname:
                 oname = os.path.splitext(r["filename"])[0]
@@ -145,6 +152,7 @@ class JsApi:
                     "height": r.get("height", 0),
                     "mime_type": r.get("mime_type", ""),
                     "is_gif": is_gif,
+                    "is_animated": is_animated,
                     "favorited": r["id"] in favorited_ids,
                     "auto_play_gif": auto_gif,
                 }
@@ -177,9 +185,15 @@ class JsApi:
         auto_gif = self._cfg.get("auto_play_gif", True)
         memes = []
         for r in rows:
-            is_gif = r.get("mime_type", "").endswith("gif") or r[
-                "filename"
-            ].lower().endswith(".gif")
+            fname = r["filename"].lower()
+            is_gif = r.get("mime_type", "").endswith("gif") or fname.endswith(".gif")
+            if is_gif:
+                is_animated = True
+            elif fname.endswith(".webp"):
+                path = self._find_meme_file(r["filename"])
+                is_animated = _is_animated(path) if path else False
+            else:
+                is_animated = False
             oname = r.get("original_name", "")
             if not oname:
                 oname = os.path.splitext(r["filename"])[0]
@@ -193,6 +207,7 @@ class JsApi:
                     "height": r.get("height", 0),
                     "mime_type": r.get("mime_type", ""),
                     "is_gif": is_gif,
+                    "is_animated": is_animated,
                     "favorited": r["id"] in favorited_ids,
                     "auto_play_gif": auto_gif,
                 }
@@ -349,6 +364,10 @@ class JsApi:
         self._db.remove_from_collection(meme_id, collection_id)
         return True
 
+    def log(self, msg, level="info"):
+        """供前端输出调试日志到终端"""
+        getattr(logger, level, logger.info)(msg)
+
     def rescan_cache(self) -> bool:
         self._webui.scan_cache()
         return True
@@ -387,13 +406,36 @@ class JsApi:
         return _check_connectivity()
 
     def download_original_image(self, url: str) -> dict:
-        """下载浏览器来源的原始图片（去掉 @ 修饰），导入到缓存"""
+        """下载浏览器来源的原始图片，或导入本地文件"""
+        s = url.strip()
+        # 本地文件：file:// URI 或裸绝对路径
+        local_path = None
+        if s.startswith("file://"):
+            from urllib.parse import unquote, urlparse
+
+            local_path = unquote(urlparse(s).path)
+            # Windows: file:///C:/path → /C:/path → 去掉前导 /
+            if len(local_path) > 3 and local_path[2] == ":":
+                local_path = local_path.lstrip("/")
+        elif s.startswith("/") and os.path.isfile(s):
+            local_path = s
+        elif len(s) > 2 and s[1] == ":" and os.path.isfile(s):
+            # Windows 裸路径: C:\Users\...
+            local_path = s
+        if local_path:
+            ids = self._webui._do_import([local_path])
+            if ids:
+                return {"ok": True, "id": ids[0]}
+            return {"ok": False, "error": "导入失败"}
+
+        clean_url = _strip_url_modifiers(s)
+
+        # 网络图片原图下载
         if not self._cfg.get("try_original_image", False):
             return {"ok": False, "error": "功能未启用"}
         conn = _check_connectivity()
         if not conn["ok"]:
             return {"ok": False, "error": "无网络连接"}
-        clean_url = _strip_url_modifiers(url)
         import shutil
         import tempfile
         from urllib.error import URLError

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -512,7 +512,7 @@ function renderGrid() {
     const img = document.createElement('img');
     img.alt = m.name;
     img.loading = 'lazy';
-    if (m.is_gif && m.auto_play_gif) {
+    if (m.is_animated && m.auto_play_gif) {
       img.src = '/api/original/' + m.id + '/' + encodeURIComponent(m.filename);
     } else {
       img.src = '/api/thumb/' + m.id + '/' + encodeURIComponent(m.filename);
@@ -525,10 +525,10 @@ function renderGrid() {
     name.textContent = dn;
     card.appendChild(name);
 
-    if (m.is_gif) {
+    if (m.is_animated) {
       const badge = document.createElement('span');
       badge.className = 'gif-badge';
-      badge.textContent = 'GIF';
+      badge.textContent = m.is_gif ? 'GIF' : 'WebP';
       card.appendChild(badge);
     }
 
@@ -1167,29 +1167,53 @@ function openSettings() { try { pywebview.api.open_settings(); } catch(e) {} }
     e.preventDefault();
     dragCounter = 0;
     overlay.classList.remove('drag-over');
+    const dt = e.dataTransfer;
+    // 从 dataTransfer 提取文件路径
     let uri = '';
-    try {
-      const types = e.dataTransfer.types;
-      if (types && types.includes && types.includes('text/uri-list')) {
-        uri = e.dataTransfer.getData('text/uri-list');
-      }
-    } catch(_) {}
-    if (uri) {
+    let file = null;
+
+    // 方式1: getData('text/uri-list') — 浏览器拖入（HTTP URL）
+    if (!uri) { try { uri = dt.getData('text/uri-list') || ''; } catch(_) {} }
+    // 方式2: getData('text/plain') — 回退
+    if (!uri) { try { uri = dt.getData('text/plain') || ''; } catch(_) {} }
+    uri = uri.trim();
+    // 方式3: items text/html → 提取 file://（GNOME 文件管理器）
+    if (!uri) {
       try {
-        const r = await api('download_original_image', uri);
-        if (r && r.ok) {
-          location.reload();
-          return;
+        if (dt.items && dt.items.length) {
+          for (let i = 0; i < dt.items.length; i++) {
+            const item = dt.items[i];
+            if (item.kind === 'string' && item.type === 'text/html') {
+              const html = await new Promise(res => item.getAsString(res));
+              if (!html) continue;
+              const text = html.replace(/<[^>]+>/g, '').trim();
+              if (text.startsWith('file://')) { uri = text; break; }
+            }
+          }
         }
       } catch(_) {}
     }
-    // 回退：文件 base64 上传
-    const files = e.dataTransfer.files;
-    if (!files || files.length === 0) return;
-    const imgExts = /\.(png|jpg|jpeg|gif|webp|bmp)$/i;
-    const items = [];
-    for (const file of files) {
-      if (!imgExts.test(file.name)) continue;
+    // 方式3: files
+    if (!uri) { try { if (dt.files && dt.files.length) file = dt.files[0]; } catch(_) {} }
+    // 方式4: items → getAsFile
+    if (!uri && !file) {
+      try {
+        if (dt.items && dt.items.length) {
+          for (let i = 0; i < dt.items.length; i++) {
+            const it = dt.items[i];
+            if (it.kind === 'file') { file = it.getAsFile(); if (file) break; }
+          }
+        }
+      } catch(_) {}
+    }
+
+    if (uri) {
+      try {
+        const r = await api('download_original_image', uri);
+        if (r && r.ok) { location.reload(); return; }
+      } catch(_) {}
+    }
+    if (file) {
       try {
         const b64 = await new Promise((resolve, reject) => {
           const reader = new FileReader();
@@ -1197,18 +1221,13 @@ function openSettings() { try { pywebview.api.open_settings(); } catch(e) {} }
           reader.onerror = () => reject(reader.error);
           reader.readAsDataURL(file);
         });
-        items.push({ name: file.name, data: b64 });
+        const res = await fetch('/api/upload/', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ files: [{ name: file.name, data: b64 }] }),
+        });
+        if (res.ok) { location.reload(); }
       } catch(_) {}
     }
-    if (items.length === 0) return;
-    try {
-      const res = await fetch('/api/upload/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ files: items }),
-      });
-      if (res.ok) { location.reload(); }
-    } catch(_) {}
   });
 })();
 

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -184,9 +184,9 @@ select:hover { border-color: var(--border-light); }
     </div>
 
     <div class="section">
-      <div class="section-title">GIF 动图</div>
+      <div class="section-title">动图</div>
       <label class="check-row">
-        <input id="s-gif" type="checkbox">GIF 动图自动播放
+        <input id="s-gif" type="checkbox">动图自动播放
       </label>
     </div>
 


### PR DESCRIPTION
**背景**

项目此前只把 WebP 当静态图处理：不识别动画、复制到剪贴板丢失动效。而 QQ/微信等聊天应用不支持 WebP 表情，只认 GIF。需要在不损失存储质量的前提下打通 WebP 动图的使用链路。

**方案**

存储保持 WebP 原文件（体积小、质量无损），粘贴时现转 GIF（仅在复制瞬间转换，可接受）。

**变更内容**

动画检测

_is_animated()：扫描文件头 ANIM chunk（WebP）和 GIF89a（GIF），纯文件头读取，快
get_memes() / get_init_data() 新增 is_animated 字段
剪贴板（Windows）

复制动画 WebP 时自动 _webp_to_gif() 转 GIF，走 _copy_gif_windows 三格式写入（CF_HDROP + 自定义 GIF + CF_DIB）
转换的 GIF 持久化到缓存目录（{hash}.gif 与源 WebP 同目录），重复复制零开销；QQ/微信通过 CF_HDROP 读取真实文件路径，保证能读到动画
GIF 量化处理：alpha ≤ 128 判透明、边缘 Floyd-Steinberg 抖动；scan_cache 跳过由 WebP 生成的同名 .gif，避免重复入库

**剪贴板（Linux）**

动图（GIF / WebP 动图）用 image/gif MIME 传给 xclip / wl-copy

**前端**

动画 WebP 自动播放（原图），GIF 徽章改为按类型显示 GIF / WebP
设置页文案 "GIF 动图自动播放" → "动图自动播放"（配置 key auto_play_gif 保持不变，兼容旧配置）
拖入导入修复

Linux/WebKit2GTK 下 GNOME Nautilus 将  URI 藏在 text/html 的 <a> 标签文本中，getData 返回空——改为提取 HTML 文本
download_original_image 支持  URI、裸绝对路径、Windows 盘符路径（C:\）
浏览器拖入的 URL 扩展名从 URL 路径或 Content-Type 推断，不再存成 .tmp
前端 base64 编码从 arrayBuffer+reduce+btoa 改为 FileReader.readAsDataURL

**测试**

ruff check src/ 和 black --check src/ 全部通过
Linux（GNOME/Wayland）：本地拖入 WebP、浏览器拖入、复制粘贴已验证
Windows：待验证（已处理文件路径、持久 GIF、量化等差异点）

@TNTXZ 