### PR TITLE
fix(webui): make drag-to-reorder actually reorder memes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,9 @@ tests/
 
 ### 自定义排序
 - `memes.sort_order` 字段存储拖拽排序结果
-- JS 网格 dragstart/dragover/drop 事件实现换位，CSS transition 做动画
-- 拖拽完成后调用 `reorder_memes(id[])` 批量更新 sort_order
+- JS 网格 mousedown/mousemove/mouseup 自定义拖拽换位（**仅未过滤的"全部表情"视图启用**），拖拽卡片以 transform 跟随指针，插入点按指针 X/Y 相对卡片中心计算（`getDropIndex`），监听器在 `initDragReorder()` 中只绑定一次（委托）
+- 拖拽完成后按新 DOM 顺序调用 `reorder_memes(id[])` 批量更新 sort_order
+- 拖拽后通过 `suppressClick` 抑制误触发的 `click`（防止误复制），下次 `mousedown` 时重置
 
 ### 多级分组（最多 3 层）
 - `collections.parent_id` 自引用实现嵌套

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -221,9 +221,9 @@ body {
 .meme-card.folder-card .name { display: none; }
 
 /* Drag and drop */
-.meme-card.dragging { opacity: .5; transform: scale(.95); }
+.meme-card.dragging { opacity: .5; transform: scale(.95); z-index: 10; position: relative; transition: none; }
 .meme-card.drag-over { border-color: var(--accent); }
-#meme-grid.drag-active .meme-card:not(.folder-card) { transition: transform 200ms ease; }
+#meme-grid.drag-active .meme-card:not(.folder-card):not(.dragging) { transition: transform 200ms ease; }
 
 /* Buttons */
 .btn {
@@ -537,53 +537,88 @@ function renderGrid() {
     grid.appendChild(card);
   });
 
-  // Custom drag-to-reorder
-  let dragActive = false, dragStartY = 0, dragCard = null, dragIdx = -1;
+}
+
+/* Drag-to-reorder (only enabled in the unfiltered "all memes" view) */
+let memeDrag = null;
+let suppressClick = false;
+
+function canReorderMemes() {
+  const q = document.getElementById('search').value.trim();
+  return !q && activeTags.size === 0 && activeCollection == null;
+}
+
+function memeCardsInGrid() {
+  return Array.from(document.querySelectorAll('#meme-grid .meme-card:not(.folder-card)'));
+}
+
+function getDropIndex(x, y, cards) {
+  for (let i = 0; i < cards.length; i++) {
+    const r = cards[i].getBoundingClientRect();
+    if (y >= r.top && y <= r.bottom) {
+      if (x < r.left + r.width / 2) return i;
+    } else if (y < r.top) {
+      return i;
+    }
+  }
+  return cards.length;
+}
+
+function clearMemeDrag() {
+  const d = memeDrag;
+  if (!d) return;
+  memeDrag = null;
+  d.card.classList.remove('dragging');
+  d.card.style.transform = '';
+  document.getElementById('meme-grid').classList.remove('drag-active');
+  memeCardsInGrid().forEach(c => { c.style.borderTop = ''; c.style.borderBottom = ''; });
+}
+
+function initDragReorder() {
+  const grid = document.getElementById('meme-grid');
+  document.addEventListener('mousedown', () => { suppressClick = false; }, true);
   grid.addEventListener('mousedown', (e) => {
-    dragCard = e.target.closest('.meme-card:not(.folder-card)');
-    if (!dragCard) return;
-    dragActive = false;
-    dragStartY = e.clientY;
-    dragIdx = Array.from(grid.children).indexOf(dragCard);
+    if (e.button !== 0) return;
+    const card = e.target.closest('.meme-card:not(.folder-card)');
+    if (!card || !canReorderMemes()) return;
+    const rect = card.getBoundingClientRect();
+    memeDrag = { card, active: false, offX: e.clientX - rect.left, offY: e.clientY - rect.top, rect };
   });
   document.addEventListener('mousemove', (e) => {
-    if (!dragCard) return;
-    if (!dragActive && Math.abs(e.clientY - dragStartY) > 8) {
-      dragActive = true;
-      dragCard.classList.add('dragging');
+    const d = memeDrag;
+    if (!d) return;
+    if (!d.active && Math.hypot(e.clientX - (d.rect.left + d.offX), e.clientY - (d.rect.top + d.offY)) > 8) {
+      d.active = true;
+      d.card.classList.add('dragging');
       grid.classList.add('drag-active');
     }
-    if (!dragActive) return;
-    const rects = grid.querySelectorAll('.meme-card:not(.folder-card)');
-    for (const rc of rects) {
-      if (rc === dragCard) continue;
-      const r = rc.getBoundingClientRect();
-      if (e.clientY > r.top && e.clientY < r.bottom) {
-        const after = e.clientY > r.top + r.height / 2;
-        rc.style.borderBottom = after ? '2px solid var(--accent)' : '';
-        rc.style.borderTop = after ? '' : '2px solid var(--accent)';
-      } else {
-        rc.style.borderBottom = '';
-        rc.style.borderTop = '';
-      }
-    }
+    if (!d.active) return;
+    d.card.style.transform = 'translate(' + (e.clientX - d.offX - d.rect.left) + 'px,' + (e.clientY - d.offY - d.rect.top) + 'px) scale(0.95)';
+    const others = memeCardsInGrid().filter(c => c !== d.card);
+    const target = getDropIndex(e.clientX, e.clientY, others);
+    others.forEach(c => { c.style.borderTop = ''; c.style.borderBottom = ''; });
+    if (target < others.length) others[target].style.borderTop = '2px solid var(--accent)';
+    else if (others.length) others[others.length - 1].style.borderBottom = '2px solid var(--accent)';
   });
-  document.addEventListener('mouseup', async () => {
-    if (!dragCard) { dragActive = false; return; }
+  document.addEventListener('mouseup', async (e) => {
+    const d = memeDrag;
+    if (!d) return;
+    memeDrag = null;
+    d.card.classList.remove('dragging');
+    d.card.style.transform = '';
     grid.classList.remove('drag-active');
-    dragCard.classList.remove('dragging');
-    grid.querySelectorAll('.meme-card').forEach(c => { c.style.borderBottom = ''; c.style.borderTop = ''; });
-    if (dragActive) {
-      const allCards = grid.querySelectorAll('.meme-card:not(.folder-card)');
-      let newIdx = memes.length - 1;
-      for (let i = 0; i < allCards.length; i++) {
-        const rc = allCards[i];
-        if (rc === dragCard) continue;
-        // Find where dragCard is inserted
-      }
-      // simpler: just rebuild memes from grid order
+    memeCardsInGrid().forEach(c => { c.style.borderTop = ''; c.style.borderBottom = ''; });
+    if (!d.active) return;
+    suppressClick = true;
+    const all = memeCardsInGrid();
+    const others = all.filter(c => c !== d.card);
+    const cur = all.indexOf(d.card);
+    const target = getDropIndex(e.clientX, e.clientY, others);
+    if (target < cur) d.card.parentNode.insertBefore(d.card, others[target]);
+    else if (target > cur) d.card.parentNode.insertBefore(d.card, others[target - 1].nextSibling);
+    if (target !== cur) {
       const ordered = [];
-      grid.querySelectorAll('.meme-card:not(.folder-card)').forEach(c => {
+      memeCardsInGrid().forEach(c => {
         const id = parseInt(c.dataset.memeId);
         const found = memes.find(x => x.id === id);
         if (found) ordered.push(found);
@@ -593,12 +628,12 @@ function renderGrid() {
         await api('reorder_memes', memes.map(x => x.id));
       }
     }
-    dragCard = null;
-    dragActive = false;
   });
+  window.addEventListener('blur', clearMemeDrag);
 }
 
 async function copyMeme(id, filename) {
+  if (suppressClick) return;
   const ok = await api('copy_meme', id);
   if (ok) {
     showToast(filename + ' 已复制');
@@ -1260,6 +1295,7 @@ async function checkUpdateAndPrompt() {
 
 /* Init */
 document.addEventListener('DOMContentLoaded', async () => {
+  initDragReorder();
   document.getElementById('loading').classList.remove('hidden');
   const data = await api('get_init_data');
   if (data) {


### PR DESCRIPTION
## 修改背景
拖拽排序存在功能性 Bug：拖拽过程中仅绘制边框指示线，DOM 顺序从未改变；松手时按原顺序重建 `memes` 并调用 `reorder_memes`，实际是空操作。同时 `renderGrid()` 每次渲染都会重复绑定 mousedown/mousemove/mouseup 监听器。

## 技术实现要点
- 新增 `getDropIndex(x, y, cards)`：逐卡片比较指针与 rect，同时考虑 X/Y 相对卡片中心，正确处理多列网格下的插入位置
- `mouseup` 时用 `insertBefore` 真正移动被拖卡片，再按新 DOM 顺序调用 `reorder_memes(id[])` 批量更新 `sort_order`
- 拖拽卡片用 `transform` 跟随指针（`position: relative` + `z-index` 浮于网格上层），CSS 对 `.dragging` 禁用 transition 保证跟手
- 监听器抽离到 `initDragReorder()`，仅初始化时绑定一次（委托 + `window.blur` 兜底清理）
- 通过 `canReorderMemes()` 将拖拽限定在未过滤的"全部表情"视图，避免搜索/标签/分组/收藏视图对过滤子集重排而污染全局排序
- `suppressClick` 在下一次 `mousedown`（捕获阶段）重置，抑制拖拽结束误触发的复制

## 测试情况
- `node --check` 通过
- 浏览器实测（mock 数据）：拖拽第 1 张到底部后 DOM 顺序变为 `[2..11, 1, 12]`，`reorder_memes` 收到正确新顺序；原地放下不触发写库；搜索视图下拖拽被禁用；拖拽后 `suppressClick` 置位
- Windows端、Linux端均通过实机测试

## 潜在影响
- 拖拽排序仅在未过滤视图可用（属于预期限制）
- 超过 200 张表情时仅对当前显示的 200 张生效（既有 limit=200 设计，未改动）

## Summary by Sourcery

修复表情包网格中的拖拽排序功能，使卡片移动时更新 DOM 顺序，并且仅在未过滤的「所有表情包」视图中持久化自定义排序。

新功能：
- 启用可用的拖拽排序功能，使表情包卡片在视觉上跟随指针移动，并根据新的 DOM 顺序更新排序。

Bug 修复：
- 防止拖拽排序成为无效果操作，通过实际在网格中重新排序表情包元素并持久化新顺序。
- 避免在拖拽操作结束后立即点击时误触发表情包复制动作。

改进：
- 将拖拽排序限制在未过滤的「所有表情包」视图中，避免由已过滤子集导致全局排序被破坏。
- 优化拖拽视觉效果，通过正确设置 z-index、定位和过渡动画，确保只有非拖拽卡片在重排时产生动画。
- 将拖拽事件监听的设置集中到单一初始化函数中，避免重复绑定，并在窗口失焦时提升清理效果。

文档：
- 更新代理文档，描述新的拖拽排序行为、其视图限制、基于指针的插入逻辑，以及拖拽后点击抑制机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix drag-to-reorder in the meme grid so that card movement updates DOM order and persists custom sort order only in the unfiltered "all memes" view.

New Features:
- Enable functional drag-to-reorder of meme cards that visually follow the pointer and update sort order based on new DOM order.

Bug Fixes:
- Prevent drag-to-reorder from being a no-op by actually reordering meme elements in the grid and persisting the new order.
- Avoid accidental meme copy actions triggered by clicks immediately following a drag operation.

Enhancements:
- Limit drag-to-reorder to the unfiltered "all memes" view to avoid corrupting global ordering from filtered subsets.
- Refine drag visuals with proper z-index, positioning, and transitions so only non-dragging cards animate during reflow.
- Centralize drag event listener setup into a single initialization function to avoid repeated bindings and improve cleanup on window blur.

Documentation:
- Update agent documentation to describe the new drag-to-reorder behavior, its view limitations, pointer-based insertion logic, and click suppression after drag operations.

</details>