### PR TITLE
refactor(webui): use Gdk.CURRENT_TIME for window drag timestamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ tests/
 - 主窗口 ~700×500 frameless, 设置窗口 460×560 frameless
 - 自定义 JS 拖拽: 鼠标事件 → `pywebview.api.move_window(dx, dy)`
 - 拖拽增量用 `clientX/clientY`（**勿改回 `screenX/screenY`** — Linux/Wayland 下 WebKitGTK 的 screenX 恒为 0 导致拖不动）；后端 `move_window` 用 `_drag_pos` 累加器避免每次 mousemove 走 `Window.x` 的 GTK 线程往返
-- **Linux 拖拽必须走合成器**：`w.move()` 在 Wayland 下无效（合成器不允许客户端自定位），mousedown 时 JS 调 `start_window_drag()` → 后端 `GLib.idle_add(native.begin_move_drag, ...)` 交给合成器交互式拖动；Windows/macOS 才走增量回退
+- **Linux 拖拽必须走合成器**：`w.move()` 在 Wayland 下无效（合成器不允许客户端自定位），mousedown 时 JS 调 `start_window_drag()` → 后端 `GLib.idle_add(native.begin_move_drag, ...)` 交给合成器交互式拖动；时间戳用 `Gdk.CURRENT_TIME`（GDK 文档允许未知时间时用它，X11 回填最近输入事件时间、Wayland 不参与）；Windows/macOS 才走增量回退
 - `#titlebar` 上可拖拽 (排除 `.title-btn` 按钮区域)
 
 ### 数据库

--- a/src/webui.py
+++ b/src/webui.py
@@ -748,12 +748,16 @@ class JsApi:
         if not w:
             return False
         try:
-            from gi.repository import GLib
+            from gi.repository import Gdk, GLib
 
             native = getattr(w, "native", None)
             if native is None:
                 return False
-            GLib.idle_add(native.begin_move_drag, button, root_x, root_y, 0)
+            # Gdk.CURRENT_TIME(0)：GDK 文档明确允许未知时间时用它，X11 下回填最近
+            # 一次真实输入事件时间，Wayland 下该参数不参与合成器拖动
+            GLib.idle_add(
+                native.begin_move_drag, button, root_x, root_y, Gdk.CURRENT_TIME
+            )
             return True
         except Exception:
             return False
@@ -1005,12 +1009,16 @@ class SettingsApi:
         if not w:
             return False
         try:
-            from gi.repository import GLib
+            from gi.repository import Gdk, GLib
 
             native = getattr(w, "native", None)
             if native is None:
                 return False
-            GLib.idle_add(native.begin_move_drag, button, root_x, root_y, 0)
+            # Gdk.CURRENT_TIME(0)：GDK 文档明确允许未知时间时用它，X11 下回填最近
+            # 一次真实输入事件时间，Wayland 下该参数不参与合成器拖动
+            GLib.idle_add(
+                native.begin_move_drag, button, root_x, root_y, Gdk.CURRENT_TIME
+            )
             return True
         except Exception:
             return False


### PR DESCRIPTION
将 begin_move_drag 的时间戳字面量 0 改为 Gdk.CURRENT_TIME 并注释依据：
GDK 文档明确允许未知时间时使用 GDK_CURRENT_TIME（"GDK_CURRENT_TIME can
be used if the time isn't known"）；X11 下 GDK 会回填最近一次真实输入事件
时间，Wayland 下该参数不参与合成器拖动。JS 桥接侧无法获取 GDK 时钟体系的
事件时间戳，故此为官方推荐的稳定取值。行为无变化。



## 结论：0（GDK_CURRENT_TIME）是被官方文档允许的稳定取值
依据（GTK3 官方文档，本机 GTK 3.24.52）：

gdk_device_grab 的 time_ 参数："The timestamp of the event which led to this pointer grab. This usually comes from the GdkEvent struct, though GDK_CURRENT_TIME can be used if the time isn't known."

## 关键点：

### X11 下：传 GDK_CURRENT_TIME 时 GDK 会用显示器的最近一次真实输入事件时间回填——正好是触发拖拽的那次 mousedown 的时间戳，grab 有效。
### Wayland 下：[begin_move_drag](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 走 xdg_toplevel.move(seat, serial)，该时间戳参数不参与合成器拖动，传 0 无影响。
### 无法获取"真实"时间戳：JS 桥接侧的 [e.timeStamp](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 是 DOM 时间戳（相对 navigationStart 的另一个时钟），无法换算成 GDK 单调时间；而且调用发生在桥接线程、并非 GTK 事件处理中，gtk_get_current_event_time() 也拿不到。所以 GDK_CURRENT_TIME 正是官方为此设计的取值。
## 已做的改动
按 reviewer 建议的第二种方式（确认 + 文档化），把字面量 0 换成自文档化的 [Gdk.CURRENT_TIME](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 并加注释：

[webui.py](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html)：两处 [start_window_drag](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 中 [from gi.repository import Gdk, GLib](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) + [GLib.idle_add(..., Gdk.CURRENT_TIME)](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) + 注释说明依据（X11 回填 / Wayland 不参与）。
[AGENTS.md](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html)：窗口章节补充 [Gdk.CURRENT_TIME](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html) 说明。
行为零变化（[Gdk.CURRENT_TIME == 0](vscode-file://vscode-app/usr/lib/code/out/vs/code/electron-browser/workbench/workbench.html)），纯粹是澄清 + 防误改。

## Summary by Sourcery

在保持运行时行为不变的前提下，澄清并文档化 GTK 窗口拖拽操作使用的时间戳。

增强内容：
- 使用 `Gdk.CURRENT_TIME` 替代字面量 `0` 作为 GTK 窗口拖拽的时间戳，以使意图更加明确并具有自说明性。

文档：
- 更新 `AGENTS.md`，记录 Linux 上窗口拖拽的行为，以及在拖拽时间戳中使用 `Gdk.CURRENT_TIME` 的原因。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and document the timestamp used for GTK window drag operations while keeping runtime behavior unchanged.

Enhancements:
- Use Gdk.CURRENT_TIME instead of a literal 0 for GTK window drag timestamps to make the intent explicit and self-documenting.

Documentation:
- Update AGENTS.md to document Linux window drag behavior and the rationale for using Gdk.CURRENT_TIME for the drag timestamp.

</details>