### PR TITLE
fix(webui):修复右键菜单超出窗口边框导致无法使用的问题

### DIFF
--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -724,13 +724,20 @@ function showCtxMenu(e, meme) {
   }
   menu.classList.add('show');
   const rect = menu.getBoundingClientRect();
-  const overflowRight = rect.right - window.innerWidth;
-  if (overflowRight > 0) {
-    menu.style.left = (e.clientX - rect.width) + 'px';
-  } else {
-    menu.style.left = e.clientX + 'px';
+  let left = e.clientX;
+  let top = e.clientY;
+
+  if (left + rect.width > window.innerWidth) {
+    left = window.innerWidth - rect.width - 4;
   }
-  menu.style.top = e.clientY + 'px';
+  if (top + rect.height > window.innerHeight) {
+    top = window.innerHeight - rect.height - 4;
+  }
+  if (left < 0) left = 4;
+  if (top < 0) top = 4;
+
+  menu.style.left = left + 'px';
+  menu.style.top = top + 'px';
 }
 
 function showFolderMenu(e, folderId, folderName) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 防止右键上下文菜单渲染超出窗口边缘，确保在所有屏幕位置都能正常使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the right‑click context menu from rendering beyond the window edges, ensuring it remains usable at all screen positions.

</details>