### PR TITLE
fix(webui): fix window drag jitter on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,8 @@ tests/
 ### 窗口
 - 主窗口 ~700×500 frameless, 设置窗口 460×560 frameless
 - 自定义 JS 拖拽: 鼠标事件 → `pywebview.api.move_window(dx, dy)`
-- 拖拽增量用 `clientX/clientY`（**勿改回 `screenX/screenY`** — Linux/Wayland 下 WebKitGTK 的 screenX 恒为 0 导致拖不动）；后端 `move_window` 用 `_drag_pos` 累加器避免每次 mousemove 走 `Window.x` 的 GTK 线程往返
-- **Linux 拖拽必须走合成器**：`w.move()` 在 Wayland 下无效（合成器不允许客户端自定位），mousedown 时 JS 调 `start_window_drag()` → 后端 `GLib.idle_add(native.begin_move_drag, ...)` 交给合成器交互式拖动；时间戳用 `Gdk.CURRENT_TIME`（GDK 文档允许未知时间时用它，X11 回填最近输入事件时间、Wayland 不参与）；Windows/macOS 才走增量回退
+- 增量回退（Windows/macOS）用 `screenX/screenY`（**勿改 `clientX/clientY`** — clientX 是相对窗口坐标，窗口自身滞后位移会被下一次 mousemove 当作反向增量回传，形成反馈振荡导致高频抖动）；Linux 走合成器原生拖动不经过此路径
+- **Linux 拖拽必须走合成器**：`w.move()` 在 Wayland 下无效（合成器不允许客户端自定位），mousedown 时 JS 调 `start_window_drag()` → 后端 `GLib.idle_add(native.begin_move_drag, ...)` 交给合成器交互式拖动；时间戳用 `Gdk.CURRENT_TIME`（GDK 文档允许未知时间时用它，X11 回填最近输入事件时间、Wayland 不参与）
 - `#titlebar` 上可拖拽 (排除 `.title-btn` 按钮区域)
 
 ### 数据库

--- a/src/webui.py
+++ b/src/webui.py
@@ -114,7 +114,6 @@ class JsApi:
         self._webui = webui
         self._cfg = get_config()
         self._db = get_db()
-        self._drag_pos = None
 
     def search_memes(
         self, keyword: str = "", tags: list = None, collection_id: int = None
@@ -729,16 +728,11 @@ class JsApi:
 
     def move_window(self, dx: int, dy: int):
         w = self._webui._window
-        if not w:
-            return
-        try:
-            if self._drag_pos is None:
-                self._drag_pos = [w.x, w.y]
-            self._drag_pos[0] += dx
-            self._drag_pos[1] += dy
-            w.move(self._drag_pos[0], self._drag_pos[1])
-        except Exception:
-            pass
+        if w:
+            try:
+                w.move(w.x + dx, w.y + dy)
+            except Exception:
+                pass
 
     def start_window_drag(self, button: int, root_x: int, root_y: int) -> bool:
         """Linux 用 GTK begin_move_drag 合成器拖动；其他平台走增量回退"""
@@ -875,7 +869,6 @@ class SettingsApi:
     def __init__(self, webui):
         self._webui = webui
         self._cfg = get_config()
-        self._drag_pos = None
 
     def check_connectivity(self) -> dict:
         return _check_connectivity()
@@ -990,16 +983,11 @@ class SettingsApi:
 
     def move_window(self, dx: int, dy: int):
         w = self._webui._settings_window
-        if not w:
-            return
-        try:
-            if self._drag_pos is None:
-                self._drag_pos = [w.x, w.y]
-            self._drag_pos[0] += dx
-            self._drag_pos[1] += dy
-            w.move(self._drag_pos[0], self._drag_pos[1])
-        except Exception:
-            pass
+        if w:
+            try:
+                w.move(w.x + dx, w.y + dy)
+            except Exception:
+                pass
 
     def start_window_drag(self, button: int, root_x: int, root_y: int) -> bool:
         """Linux 用 GTK begin_move_drag 合成器拖动；其他平台走增量回退"""

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -1281,15 +1281,15 @@ titlebar.addEventListener('mousedown', async (e) => {
   if (e.target.closest('.title-btn')) return;
   const nativeDrag = await api('start_window_drag', e.button + 1, e.screenX, e.screenY);
   if (nativeDrag) return;   // Linux：交给合成器拖动
-  dragState = { x: e.clientX, y: e.clientY };
+  dragState = { sx: e.screenX, sy: e.screenY };
   e.preventDefault();
 });
 document.addEventListener('mousemove', (e) => {
   if (!dragState) return;
-  const dx = e.clientX - dragState.x, dy = e.clientY - dragState.y;
+  const dx = e.screenX - dragState.sx, dy = e.screenY - dragState.sy;
   if (dx !== 0 || dy !== 0) {
     api('move_window', dx, dy);
-    dragState.x = e.clientX; dragState.y = e.clientY;
+    dragState.sx = e.screenX; dragState.sy = e.screenY;
   }
 });
 document.addEventListener('mouseup', () => { dragState = null; });

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -1284,15 +1284,15 @@ titlebar.addEventListener('mousedown', async (e) => {
   if (e.target.closest('.title-btn')) return;
   const nativeDrag = await api('start_window_drag', e.button + 1, e.screenX, e.screenY);
   if (nativeDrag) return;   // Linux：交给合成器拖动
-  dragState = { x: e.clientX, y: e.clientY };
+  dragState = { sx: e.screenX, sy: e.screenY };
   e.preventDefault();
 });
 document.addEventListener('mousemove', (e) => {
   if (!dragState) return;
-  const dx = e.clientX - dragState.x, dy = e.clientY - dragState.y;
+  const dx = e.screenX - dragState.sx, dy = e.screenY - dragState.sy;
   if (dx !== 0 || dy !== 0) {
     api('move_window', dx, dy);
-    dragState.x = e.clientX; dragState.y = e.clientY;
+    dragState.sx = e.screenX; dragState.sy = e.screenY;
   }
 });
 document.addEventListener('mouseup', () => { dragState = null; });


### PR DESCRIPTION
## 修改背景
修复 Windows 上无边框窗口拖拽时的高频抖动。此前为修复 Linux 拖拽
将增量坐标由 `screenX/screenY` 改为 `clientX/clientY`，导致 Windows
拖动出现反馈振荡。

## 技术实现要点
- **根因**：`clientX/clientY` 是相对窗口（视口）的坐标，会随窗口移动
  而变化。异步桥接下窗口存在滞后位移，该位移会被下一次 `mousemove`
  当作反向增量回传，形成反馈回路，表现为高频抖动；`screenX/screenY`
  为屏幕绝对坐标，与窗口位置无关，无此问题
- **前端（主窗口 + 设置窗口）**：增量回退恢复使用 `screenX/screenY`
  （mousedown 播种与 mousemove 增量均改回）；保留 `start_window_drag`
  Linux 原生拖动路径不变
- **后端 `webui.py`**：`move_window` 恢复为 `w.move(w.x + dx, w.y + dy)`，
  移除 `_drag_pos` 累加器及其初始化——该累加器原为避免 Linux 的 GTK
  线程往返，Linux 现已走合成器原生拖动不经过增量路径，保留反而引入
  跨拖拽的坐标漂移风险

## 测试情况
- ruff / black 通过；两处 HTML 的 JS 语法检查通过；现有 25 个测试全部通过
- Linux 端验证：合成器原生拖动正常（不受本次改动影响，未经过增量路径）
- Windows 端验证：拖动平滑无抖动

## 潜在影响
- 仅影响窗口拖拽的增量回退路径（Windows/macOS），Linux 原生拖动路径不变
- 无破坏性变更

## Summary by Sourcery

通过恢复基于屏幕的拖拽增量并简化后端窗口移动逻辑，在保持 Linux 使用原生合成器拖拽的同时，恢复稳定的无边框窗口拖动。

Bug Fixes:
- 通过基于屏幕坐标而非客户端坐标计算拖拽增量，修复在 Windows（以及其他使用增量拖拽的平台）上拖动无边框窗口时出现的高频抖动问题。

Enhancements:
- 通过移除拖拽位置累加器并依赖相对于当前窗口位置的相对移动，简化后端的窗口移动处理逻辑。

Documentation:
- 更新代理（agent）文档，描述 Windows/macOS 上基于屏幕坐标的增量拖拽路径，并澄清 Linux 始终使用合成器原生拖拽方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore stable frameless window dragging by reverting to screen-based drag deltas and simplifying backend window movement while keeping Linux on native compositor drag.

Bug Fixes:
- Fix high-frequency jitter when dragging frameless windows on Windows (and other incremental-drag platforms) by basing drag deltas on screen coordinates instead of client coordinates.

Enhancements:
- Simplify window move handling in the backend by removing drag position accumulators and relying on relative moves from the current window position.

Documentation:
- Update agent documentation to describe the screen-coordinate based incremental drag path for Windows/macOS and clarify that Linux always uses compositor-native dragging.

</details>