### PR TITLE
fix: WebDAV 同步后端加固（失败项显示 / 互斥锁 / 中断清理 / 远端孤儿GC）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ tests/
 ### 同步
 - manifest 文件: `meme-index.json`
 - SHA-256 差异对比, `push(delete_remote)`/`pull(remove_local)`
-- 远端路径: `{root}/memes/`, `{root}/thumbnails/`, `{root}/meme-index.json`
+- 远端路径: `{root}/memes/`, `{root}/meme-index.json`
 - 同步进度: `_sync_state` 全局变量追踪进度，`get_sync_progress()` 供 JS 轮询
 - `push()`/`pull()` 内循环中更新 files_done/bytes_done/current_file 等字段
 - 前端 300ms 轮询 `get_sync_progress()` 显示进度条 + 实时速度
@@ -121,7 +121,6 @@ tests/
 - `_push_worker`/`_pull_worker`: 接收文件子列表，操作独立后端连接，原子递增 `_sync_state`
 - `_sync_lock` (`threading.Lock`) 保护 `_sync_state` 写操作；`_increment_sync_progress()` 提供原子递增
 - `_chunk_list(lst, n)` 将文件列表均匀切分给各线程
-- 缩略图上传统一由文件所在 worker 附带完成
 
 ### 更新
 - GitHub API 查询: `/releases/latest` → `/releases?per_page=5` 回退

--- a/src/config.py
+++ b/src/config.py
@@ -97,6 +97,7 @@ class Config:
         "webdav_user": "",
         "webdav_password": "",
         "webdav_path": "",
+        "webdav_timeout": 30,  # WebDAV 请求超时（秒）
         # 复制设置
         "copy_resize_mode": 1,  # 0不处理；1webp缩放；2转gif；3转gif隐写原图
         "copy_resize_max": 200,  # 缩放后最长边像素

--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,14 @@ class OhMyMemeApp:
     def run(self):
         self._running = True
 
+        # 0. 清理中断遗留的临时文件（.remote-* / *.tmp）
+        try:
+            from .sync import cleanup_stale_temp_files
+
+            cleanup_stale_temp_files()
+        except Exception as e:
+            logger.debug("cleanup stale temp files: %s", e)
+
         # 1. 创建 WebUI（先不启动 GUI 循环）
         self._webui = WebUI(
             update_debug=getattr(self, "_update_debug", False),

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -70,9 +70,9 @@ def build() -> List[Dict]:
     path = _index_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
-        )
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, path)  # 原子替换，避免中断留下半写清单
         logger.debug(
             f"manifest written: {len(memes)} memes, {len(collections)} collections"
         )

--- a/src/sync.py
+++ b/src/sync.py
@@ -467,7 +467,7 @@ class _WebDAVBackend(_SyncBackend):
                     data=f,
                     headers={"Content-Length": str(size)},
                 ) as resp:
-                    return resp.status in (200, 201, 204)
+                    return 200 <= resp.status < 300
         except Exception as e:
             logger.warning("upload failed %s: %s", remote_path, e)
             return False
@@ -798,6 +798,11 @@ def push(delete_remote: bool = None) -> dict:
                 aggregated["errors"] += r["errors"]
                 aggregated["bytes"] += r["bytes"]
 
+        if aggregated["errors"] > 0:
+            msg = "%d 个文件上传失败，未更新远端 manifest" % aggregated["errors"]
+            logger.warning("sync push aborted: %s", msg)
+            raise SyncError(msg)
+
         results = {
             "uploaded": aggregated["uploaded"],
             "skipped": aggregated["skipped"],
@@ -821,7 +826,9 @@ def push(delete_remote: bool = None) -> dict:
         build_manifest()
         remote_manifest_path = remote_root.rstrip("/") + "/" + REMOTE_INDEX
         local_index = cfg.data_dir / INDEX_FILENAME
-        bk.upload_file(local_index, remote_manifest_path)
+        ok = bk.upload_file(local_index, remote_manifest_path)
+        if not ok:
+            raise SyncError("远端 manifest 上传失败")
 
         _update_sync_state(
             status="done",

--- a/src/sync.py
+++ b/src/sync.py
@@ -588,15 +588,20 @@ def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
             fsize = local_file.stat().st_size if local_file.exists() else 0
             local_hash = entry["sha256"]
             remote_entry = remote_memes.get(fname)
+            rem_path = remote_root.rstrip("/") + "/" + REMOTE_MEME_DIR + "/" + fname
             if remote_entry and remote_entry.get("sha256") == local_hash:
-                local_results["skipped"] += 1
-                _increment_sync_progress(files_add=1)
-                continue
+                try:
+                    remote_ok = bk.file_exists(rem_path)
+                except Exception:
+                    remote_ok = False
+                if remote_ok:
+                    local_results["skipped"] += 1
+                    _increment_sync_progress(files_add=1)
+                    continue
             if not local_file.exists():
                 local_results["errors"] += 1
                 _increment_sync_progress(files_add=1)
                 continue
-            rem_path = remote_root.rstrip("/") + "/" + REMOTE_MEME_DIR + "/" + fname
             bk.ensure_remote_dir(os.path.dirname(rem_path))
             if bk.upload_file(local_file, rem_path):
                 local_results["uploaded"] += 1

--- a/src/sync.py
+++ b/src/sync.py
@@ -38,6 +38,7 @@ _sync_state = {
     "start_time": 0,
     "results": None,
     "error": "",
+    "failed_items": [],  # [{filename, status: error|unknown, error}]
 }
 
 
@@ -56,6 +57,7 @@ def _reset_sync_state(direction, files_total, bytes_total):
         start_time=0,
         results=None,
         error="",
+        failed_items=[],
     )
 
 
@@ -665,7 +667,7 @@ def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
     """单线程批量上传一批文件"""
     bk = _get_backend()
     bk.connect()
-    local_results = {"uploaded": 0, "skipped": 0, "errors": 0, "bytes": 0}
+    local_results = {"uploaded": 0, "skipped": 0, "errors": 0, "bytes": 0, "failed": []}
     try:
         for entry in entries:
             fname = entry["filename"]
@@ -685,6 +687,9 @@ def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
                     continue
             if not local_file.exists():
                 local_results["errors"] += 1
+                local_results["failed"].append(
+                    {"filename": fname, "status": "error", "error": "本地文件缺失"}
+                )
                 _increment_sync_progress(files_add=1)
                 continue
             bk.ensure_remote_dir(os.path.dirname(rem_path))
@@ -694,6 +699,9 @@ def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
                 _increment_sync_progress(files_add=1, bytes_add=fsize)
             else:
                 local_results["errors"] += 1
+                local_results["failed"].append(
+                    {"filename": fname, "status": "error", "error": "上传失败"}
+                )
                 _increment_sync_progress(files_add=1)
             thumb_file = thumb_dir / ("%s_thumb.png" % fname)
             if thumb_file.exists():
@@ -714,6 +722,13 @@ def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
         if remaining > 0:
             local_results["errors"] += remaining
             _increment_sync_progress(files_add=remaining)
+            local_results["failed"].append(
+                {
+                    "filename": "",
+                    "status": "error",
+                    "error": "%d 个文件因 worker 中断未处理" % remaining,
+                }
+            )
         return local_results
     finally:
         bk.close()
@@ -723,7 +738,13 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
     """单线程批量下载一批文件"""
     bk = _get_backend()
     bk.connect()
-    local_results = {"downloaded": 0, "skipped": 0, "errors": 0, "bytes": 0}
+    local_results = {
+        "downloaded": 0,
+        "skipped": 0,
+        "errors": 0,
+        "bytes": 0,
+        "failed": [],
+    }
     local_idx = {}
     try:
         from .manifest import load as _load_manifest
@@ -750,6 +771,9 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
                 if local_path.stat().st_size == 0:
                     # 下载到空文件视为失败：清理并计错误，避免污染本地清单
                     local_results["errors"] += 1
+                    local_results["failed"].append(
+                        {"filename": fname, "status": "error", "error": "下载内容为空"}
+                    )
                     _increment_sync_progress(files_add=1)
                     try:
                         local_path.unlink()
@@ -782,6 +806,13 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
                         # DB 写入失败：清理残留 cache，避免“文件在但无记录”的游离态
                         logger.warning("pull db add failed %s: %s", fname, e)
                         local_results["errors"] += 1
+                        local_results["failed"].append(
+                            {
+                                "filename": fname,
+                                "status": "error",
+                                "error": "数据库写入失败",
+                            }
+                        )
                         _increment_sync_progress(files_add=1)
                         try:
                             local_path.unlink()
@@ -793,6 +824,9 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
                 _increment_sync_progress(files_add=1, bytes_add=fsize)
             else:
                 local_results["errors"] += 1
+                local_results["failed"].append(
+                    {"filename": fname, "status": "error", "error": "下载失败"}
+                )
                 _increment_sync_progress(files_add=1)
             rem_thumb = remote_root.rstrip("/") + "/" + REMOTE_THUMB_DIR + "/" + fname
             local_thumb = thumb_dir / fname
@@ -810,6 +844,13 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
         if remaining > 0:
             local_results["errors"] += remaining
             _increment_sync_progress(files_add=remaining)
+            local_results["failed"].append(
+                {
+                    "filename": "",
+                    "status": "error",
+                    "error": "%d 个文件因 worker 中断未处理" % remaining,
+                }
+            )
         return local_results
     finally:
         bk.close()
@@ -919,7 +960,13 @@ def push(delete_remote: bool = None) -> dict:
         else:
             chunks = _chunk_list(entries, min(max_workers, len(entries)))
 
-        aggregated = {"uploaded": 0, "skipped": 0, "errors": 0, "bytes": 0}
+        aggregated = {
+            "uploaded": 0,
+            "skipped": 0,
+            "errors": 0,
+            "bytes": 0,
+            "failed": [],
+        }
         with ThreadPoolExecutor(max_workers=len(chunks)) as executor:
             futures = [
                 executor.submit(
@@ -933,17 +980,21 @@ def push(delete_remote: bool = None) -> dict:
                 aggregated["skipped"] += r["skipped"]
                 aggregated["errors"] += r["errors"]
                 aggregated["bytes"] += r["bytes"]
+                aggregated["failed"].extend(r.get("failed", []))
 
         if aggregated["errors"] > 0:
+            _update_sync_state(failed_items=aggregated["failed"])
             msg = "%d 个文件上传失败，未更新远端 manifest" % aggregated["errors"]
             logger.warning("sync push aborted: %s", msg)
             raise SyncError(msg)
 
+        failed_files = list(aggregated["failed"])
         results = {
             "uploaded": aggregated["uploaded"],
             "skipped": aggregated["skipped"],
             "errors": aggregated["errors"],
             "deleted": 0,
+            "failed_files": failed_files,
         }
 
         deleted_fnames = set()
@@ -958,15 +1009,29 @@ def push(delete_remote: bool = None) -> dict:
                         results["deleted"] += 1
                     else:
                         # 删除结果不确定：复核远端是否真的已删
+                        unknown = False
                         try:
                             still = bk.file_exists(rem_path)
                         except Exception:
-                            still = True  # 复核异常 → unknown，保留待下次重查
+                            still = True
+                            unknown = True  # 复核异常 → unknown，保留待下次重查
                         if not still:
                             # 复核确认已删 → 视为删除成功
                             deleted_fnames.add(fname)
                             results["deleted"] += 1
-                        # still=True（仍在或复核异常）→ 保留在远端 manifest
+                        else:
+                            # 仍在/未知 → 保留在远端 manifest，记录失败供 UI 展示
+                            failed_files.append(
+                                {
+                                    "filename": fname,
+                                    "status": "unknown" if unknown else "error",
+                                    "error": (
+                                        "删除结果不确定，将在下次同步复核"
+                                        if unknown
+                                        else "远端删除失败（文件仍存在）"
+                                    ),
+                                }
+                            )
                     rem_thumb = (
                         remote_root.rstrip("/") + "/" + REMOTE_THUMB_DIR + "/" + fname
                     )
@@ -1012,6 +1077,7 @@ def push(delete_remote: bool = None) -> dict:
             files_done=files_total,
             bytes_done=bytes_total,
             results=results,
+            failed_items=results["failed_files"],
         )
         logger.info("sync push done: %s", results)
         return results
@@ -1086,7 +1152,13 @@ def pull(remove_local: bool = None) -> dict:
         else:
             chunks = _chunk_list(entries, min(max_workers, len(entries)))
 
-        aggregated = {"downloaded": 0, "skipped": 0, "errors": 0, "bytes": 0}
+        aggregated = {
+            "downloaded": 0,
+            "skipped": 0,
+            "errors": 0,
+            "bytes": 0,
+            "failed": [],
+        }
         with ThreadPoolExecutor(max_workers=len(chunks)) as executor:
             futures = [
                 executor.submit(_pull_worker, ch, remote_root, cache_dir, thumb_dir, db)
@@ -1098,12 +1170,14 @@ def pull(remove_local: bool = None) -> dict:
                 aggregated["skipped"] += r["skipped"]
                 aggregated["errors"] += r["errors"]
                 aggregated["bytes"] += r["bytes"]
+                aggregated["failed"].extend(r.get("failed", []))
 
         results = {
             "downloaded": aggregated["downloaded"],
             "skipped": aggregated["skipped"],
             "errors": aggregated["errors"],
             "removed_local": 0,
+            "failed_files": aggregated["failed"],
         }
 
         if remove_local:
@@ -1129,6 +1203,7 @@ def pull(remove_local: bool = None) -> dict:
         _apply_remote_collections(remote_data)
         build_manifest()
         if aggregated["errors"] > 0:
+            _update_sync_state(failed_items=aggregated["failed"])
             msg = "%d 个文件下载失败，本地清单仅包含成功项" % aggregated["errors"]
             logger.warning("sync pull aborted: %s", msg)
             raise SyncError(msg)
@@ -1139,6 +1214,7 @@ def pull(remove_local: bool = None) -> dict:
             files_done=files_total,
             bytes_done=bytes_total,
             results=results,
+            failed_items=results["failed_files"],
         )
         logger.info("sync pull done: %s", results)
         return results

--- a/src/sync.py
+++ b/src/sync.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import tempfile
 import threading
 import time
 import urllib.error
@@ -636,13 +637,19 @@ def _fetch_remote_memes(bk, remote_root):
     remote_path = remote_root.rstrip("/") + "/" + REMOTE_INDEX
     if not bk.file_exists(remote_path):
         return {}
-    tmp = cfg.data_dir / ".remote-index.json"
-    if not bk.download_file(remote_path, tmp):
-        raise SyncError("远端 manifest 下载失败")
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".remote-index-", suffix=".json", dir=str(cfg.data_dir)
+    )
+    os.close(fd)
+    tmp = Path(tmp_name)
     try:
+        if not bk.download_file(remote_path, tmp):
+            raise SyncError("远端 manifest 下载失败")
         raw_bytes = tmp.read_bytes()
         rdata = json.loads(raw_bytes.decode("utf-8"))
         return {m["filename"]: m for m in rdata.get("memes", [])}
+    except SyncError:
+        raise
     except Exception as e:
         raise SyncError("远端 manifest 解析失败: %s" % e)
     finally:
@@ -837,7 +844,11 @@ def download_index() -> Optional[dict]:
     """
     cfg = get_config()
     remote_root = _remote_root(cfg)
-    tmp = cfg.data_dir / ".remote-index.json"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".remote-index-", suffix=".json", dir=str(cfg.data_dir)
+    )
+    os.close(fd)
+    tmp = Path(tmp_name)
     bk = _get_backend()
     bk.connect()
     try:
@@ -969,7 +980,11 @@ def push(delete_remote: bool = None) -> dict:
             manifest_file = cfg.data_dir / INDEX_FILENAME
             if kept:
                 data["memes"].extend(kept)
-                merged_file = cfg.data_dir / ".remote-merged.json"
+                fd, tmp_name = tempfile.mkstemp(
+                    prefix=".remote-merged-", suffix=".json", dir=str(cfg.data_dir)
+                )
+                os.close(fd)
+                merged_file = Path(tmp_name)
                 merged_file.write_text(
                     json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
                 )
@@ -1191,3 +1206,23 @@ def cleanup_remote_orphans(delete: bool = False) -> dict:
         return {"ok": False, "error": str(e)}
     finally:
         bk.close()
+
+
+def cleanup_stale_temp_files() -> int:
+    """清理数据目录下中断遗留的临时文件（.remote-* / *.tmp），返回清理数量。"""
+    cfg = get_config()
+    data_dir = cfg.data_dir
+    if not data_dir.exists():
+        return 0
+    count = 0
+    for p in data_dir.iterdir():
+        if not p.is_file():
+            continue
+        name = p.name
+        if name.startswith(".remote-") or name.endswith(".tmp"):
+            try:
+                p.unlink()
+                count += 1
+            except Exception:
+                pass
+    return count

--- a/src/sync.py
+++ b/src/sync.py
@@ -201,7 +201,9 @@ class _FtpBackend(_SyncBackend):
         try:
             self.ftp.delete(path)
             return True
-        except error_perm:
+        except error_perm as e:
+            if "550" in str(e):  # 550说明文件不存在，视为删除成功
+                return True
             return False
         except Exception as e:
             logger.warning("delete failed %s: %s", path, e)
@@ -503,6 +505,11 @@ class _WebDAVBackend(_SyncBackend):
         try:
             with self._request("DELETE", self._url(path)) as resp:
                 return resp.status in (200, 204)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:  # 404说明目标不存在，视为删除成功
+                return True
+            logger.warning("delete failed %s -> HTTP %d", path, e.code)
+            return False
         except Exception as e:
             logger.warning("delete failed %s: %s", path, e)
             return False
@@ -547,20 +554,20 @@ def _remote_root(cfg) -> str:
 
 
 def _fetch_remote_memes(bk, remote_root):
-    """下载远端 manifest 并返回 {filename: entry} 字典"""
+    """下载远端 manifest 并返回 {filename: entry} 字典（无 manifest 返回 {}）"""
     cfg = get_config()
     remote_path = remote_root.rstrip("/") + "/" + REMOTE_INDEX
     if not bk.file_exists(remote_path):
         return {}
     tmp = cfg.data_dir / ".remote-index.json"
     if not bk.download_file(remote_path, tmp):
-        return {}
+        raise SyncError("远端 manifest 下载失败")
     try:
         raw_bytes = tmp.read_bytes()
         rdata = json.loads(raw_bytes.decode("utf-8"))
         return {m["filename"]: m for m in rdata.get("memes", [])}
-    except Exception:
-        return {}
+    except Exception as e:
+        raise SyncError("远端 manifest 解析失败: %s" % e)
     finally:
         if tmp.exists():
             tmp.unlink()
@@ -637,7 +644,11 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
     try:
         for fname, rentry in entries:
             local_entry = local_idx.get(fname)
-            if local_entry and local_entry.get("sha256") == rentry.get("sha256"):
+            if (
+                local_entry
+                and local_entry.get("sha256") == rentry.get("sha256")
+                and (cache_dir / fname).exists()
+            ):
                 local_results["skipped"] += 1
                 _increment_sync_progress(files_add=1)
                 continue
@@ -645,27 +656,47 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
             local_path = cache_dir / fname
             fsize = rentry.get("file_size", 0)
             if bk.download_file(rem_path, local_path):
-                row = db.get_by_filename(fname)
-                if not row:
-                    ext = os.path.splitext(fname)[1].lower()
-                    w = h = 0
+                if local_path.stat().st_size == 0:
+                    # 下载到空文件视为失败：清理并计错误，避免污染本地清单
+                    local_results["errors"] += 1
+                    _increment_sync_progress(files_add=1)
                     try:
-                        from PIL import Image as PILImage
-
-                        img = PILImage.open(local_path)
-                        w, h = img.size
+                        local_path.unlink()
                     except Exception:
                         pass
-                    oname = rentry.get("name", "") or os.path.splitext(fname)[0]
-                    db.add_meme(
-                        filename=fname,
-                        file_hash=rentry.get("sha256", ""),
-                        width=w,
-                        height=h,
-                        file_size=local_path.stat().st_size,
-                        mime_type="image/%s" % ext[1:] if ext else "image/png",
-                        original_name=oname,
-                    )
+                    continue
+                row = db.get_by_filename(fname)
+                if not row:
+                    try:
+                        ext = os.path.splitext(fname)[1].lower()
+                        w = h = 0
+                        try:
+                            from PIL import Image as PILImage
+
+                            img = PILImage.open(local_path)
+                            w, h = img.size
+                        except Exception:
+                            pass
+                        oname = rentry.get("name", "") or os.path.splitext(fname)[0]
+                        db.add_meme(
+                            filename=fname,
+                            file_hash=rentry.get("sha256", ""),
+                            width=w,
+                            height=h,
+                            file_size=local_path.stat().st_size,
+                            mime_type="image/%s" % ext[1:] if ext else "image/png",
+                            original_name=oname,
+                        )
+                    except Exception as e:
+                        # DB 写入失败：清理残留 cache，避免“文件在但无记录”的游离态
+                        logger.warning("pull db add failed %s: %s", fname, e)
+                        local_results["errors"] += 1
+                        _increment_sync_progress(files_add=1)
+                        try:
+                            local_path.unlink()
+                        except Exception:
+                            pass
+                        continue
                 local_results["downloaded"] += 1
                 local_results["bytes"] += fsize
                 _increment_sync_progress(files_add=1, bytes_add=fsize)
@@ -718,7 +749,10 @@ def upload_index(bk=None) -> bool:
 
 
 def download_index() -> Optional[dict]:
-    """从远端下载 manifest，返回解析后的 dict 或 None"""
+    """从远端下载 manifest。
+
+    无 manifest 返回 None；读取/解析失败抛 SyncError。
+    """
     cfg = get_config()
     remote_root = _remote_root(cfg)
     tmp = cfg.data_dir / ".remote-index.json"
@@ -729,13 +763,15 @@ def download_index() -> Optional[dict]:
         if not bk.file_exists(remote_path):
             return None
         if not bk.download_file(remote_path, tmp):
-            return None
+            raise SyncError("远端 manifest 下载失败")
         raw_bytes = tmp.read_bytes()
         data = json.loads(raw_bytes.decode("utf-8"))
         return data
+    except SyncError:
+        raise
     except Exception as e:
         logger.warning("download_index failed: %s", e)
-        return None
+        raise SyncError("远端 manifest 解析失败: %s" % e)
     finally:
         bk.close()
         if tmp.exists():
@@ -810,6 +846,7 @@ def push(delete_remote: bool = None) -> dict:
             "deleted": 0,
         }
 
+        deleted_fnames = set()
         if delete_remote:
             for fname in list(remote_memes.keys()):
                 if fname not in local_idx:
@@ -817,7 +854,19 @@ def push(delete_remote: bool = None) -> dict:
                         remote_root.rstrip("/") + "/" + REMOTE_MEME_DIR + "/" + fname
                     )
                     if bk.delete_file(rem_path):
+                        deleted_fnames.add(fname)
                         results["deleted"] += 1
+                    else:
+                        # 删除结果不确定：复核远端是否真的已删
+                        try:
+                            still = bk.file_exists(rem_path)
+                        except Exception:
+                            still = True  # 复核异常 → unknown，保留待下次重查
+                        if not still:
+                            # 复核确认已删 → 视为删除成功
+                            deleted_fnames.add(fname)
+                            results["deleted"] += 1
+                        # still=True（仍在或复核异常）→ 保留在远端 manifest
                     rem_thumb = (
                         remote_root.rstrip("/") + "/" + REMOTE_THUMB_DIR + "/" + fname
                     )
@@ -825,10 +874,33 @@ def push(delete_remote: bool = None) -> dict:
 
         build_manifest()
         remote_manifest_path = remote_root.rstrip("/") + "/" + REMOTE_INDEX
-        local_index = cfg.data_dir / INDEX_FILENAME
-        ok = bk.upload_file(local_index, remote_manifest_path)
-        if not ok:
-            raise SyncError("远端 manifest 上传失败")
+        merged_file = None
+        try:
+            # 远端仍保留、但本地清单没有的项合并进待上传清单，避免孤儿
+            data = load_manifest()
+            local_fnames = {m["filename"] for m in data["memes"]}
+            kept = [
+                m
+                for fname, m in remote_memes.items()
+                if fname not in local_fnames and fname not in deleted_fnames
+            ]
+            manifest_file = cfg.data_dir / INDEX_FILENAME
+            if kept:
+                data["memes"].extend(kept)
+                merged_file = cfg.data_dir / ".remote-merged.json"
+                merged_file.write_text(
+                    json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+                manifest_file = merged_file
+            ok = bk.upload_file(manifest_file, remote_manifest_path)
+            if not ok:
+                raise SyncError("远端 manifest 上传失败")
+        finally:
+            if merged_file is not None and merged_file.exists():
+                try:
+                    merged_file.unlink()
+                except Exception:
+                    pass
 
         _update_sync_state(
             status="done",
@@ -881,80 +953,89 @@ def pull(remove_local: bool = None) -> dict:
     max_workers = max(1, min(8, int(cfg.get("sync_threads", 3))))
     db = get_db()
 
-    remote_data = download_index()
-    if not remote_data:
-        raise SyncError("no remote manifest available")
+    try:
+        remote_data = download_index()
+        if not remote_data:
+            raise SyncError("no remote manifest available")
 
-    remote_idx = {m["filename"]: m for m in remote_data.get("memes", [])}
-    local_data = load_manifest()
-    local_idx = {m["filename"]: m for m in local_data.get("memes", [])}
+        remote_idx = {m["filename"]: m for m in remote_data.get("memes", [])}
+        local_data = load_manifest()
+        local_idx = {m["filename"]: m for m in local_data.get("memes", [])}
 
-    files_total = len(remote_idx)
-    bytes_total = 0
-    for m in remote_data.get("memes", []):
-        bytes_total += m.get("file_size", 0)
+        files_total = len(remote_idx)
+        bytes_total = 0
+        for m in remote_data.get("memes", []):
+            bytes_total += m.get("file_size", 0)
 
-    _reset_sync_state("download", files_total, bytes_total)
-    start = time.time()
-    _update_sync_state(status="downloading", start_time=start)
+        _reset_sync_state("download", files_total, bytes_total)
+        start = time.time()
+        _update_sync_state(status="downloading", start_time=start)
 
-    entries = list(remote_idx.items())
-    if max_workers <= 1 or len(entries) <= 1:
-        chunks = [entries]
-    else:
-        chunks = _chunk_list(entries, min(max_workers, len(entries)))
+        entries = list(remote_idx.items())
+        if max_workers <= 1 or len(entries) <= 1:
+            chunks = [entries]
+        else:
+            chunks = _chunk_list(entries, min(max_workers, len(entries)))
 
-    aggregated = {"downloaded": 0, "skipped": 0, "errors": 0, "bytes": 0}
-    with ThreadPoolExecutor(max_workers=len(chunks)) as executor:
-        futures = [
-            executor.submit(_pull_worker, ch, remote_root, cache_dir, thumb_dir, db)
-            for ch in chunks
-        ]
-        for future in as_completed(futures):
-            r = future.result()
-            aggregated["downloaded"] += r["downloaded"]
-            aggregated["skipped"] += r["skipped"]
-            aggregated["errors"] += r["errors"]
-            aggregated["bytes"] += r["bytes"]
+        aggregated = {"downloaded": 0, "skipped": 0, "errors": 0, "bytes": 0}
+        with ThreadPoolExecutor(max_workers=len(chunks)) as executor:
+            futures = [
+                executor.submit(_pull_worker, ch, remote_root, cache_dir, thumb_dir, db)
+                for ch in chunks
+            ]
+            for future in as_completed(futures):
+                r = future.result()
+                aggregated["downloaded"] += r["downloaded"]
+                aggregated["skipped"] += r["skipped"]
+                aggregated["errors"] += r["errors"]
+                aggregated["bytes"] += r["bytes"]
 
-    results = {
-        "downloaded": aggregated["downloaded"],
-        "skipped": aggregated["skipped"],
-        "errors": aggregated["errors"],
-        "removed_local": 0,
-    }
+        results = {
+            "downloaded": aggregated["downloaded"],
+            "skipped": aggregated["skipped"],
+            "errors": aggregated["errors"],
+            "removed_local": 0,
+        }
 
-    if remove_local:
-        for fname in list(local_idx.keys()):
-            if fname not in remote_idx:
-                row = db.get_by_filename(fname)
-                if row:
-                    db.delete_meme(row["id"])
-                local_path = cache_dir / fname
-                if local_path.exists():
-                    try:
-                        local_path.unlink()
-                        results["removed_local"] += 1
-                    except Exception:
-                        pass
-                thumb_path = thumb_dir / fname
-                if thumb_path.exists():
-                    try:
-                        thumb_path.unlink()
-                    except Exception:
-                        pass
+        if remove_local:
+            for fname in list(local_idx.keys()):
+                if fname not in remote_idx:
+                    row = db.get_by_filename(fname)
+                    if row:
+                        db.delete_meme(row["id"])
+                    local_path = cache_dir / fname
+                    if local_path.exists():
+                        try:
+                            local_path.unlink()
+                            results["removed_local"] += 1
+                        except Exception:
+                            pass
+                    thumb_path = thumb_dir / fname
+                    if thumb_path.exists():
+                        try:
+                            thumb_path.unlink()
+                        except Exception:
+                            pass
 
-    _apply_remote_collections(remote_data)
-    build_manifest()
-    _update_sync_state(
-        status="done",
-        progress=100,
-        files_done=files_total,
-        bytes_done=bytes_total,
-        results=results,
-    )
-    logger.info("sync pull done: %s", results)
-    return results
+        _apply_remote_collections(remote_data)
+        build_manifest()
+        if aggregated["errors"] > 0:
+            msg = "%d 个文件下载失败，本地清单仅包含成功项" % aggregated["errors"]
+            logger.warning("sync pull aborted: %s", msg)
+            raise SyncError(msg)
+
+        _update_sync_state(
+            status="done",
+            progress=100,
+            files_done=files_total,
+            bytes_done=bytes_total,
+            results=results,
+        )
+        logger.info("sync pull done: %s", results)
+        return results
+    except Exception as e:
+        _update_sync_state(status="error", error=str(e))
+        raise
 
 
 def delete_all_remote() -> dict:

--- a/src/sync.py
+++ b/src/sync.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import shutil
 import tempfile
 import threading
 import time
@@ -12,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from ftplib import FTP, error_perm
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote, unquote, urlparse
 
 from .config import get_config
 from .database import get_db
@@ -96,7 +98,6 @@ def get_sync_progress() -> dict:
 
 REMOTE_INDEX = INDEX_FILENAME
 REMOTE_MEME_DIR = "memes"
-REMOTE_THUMB_DIR = "thumbnails"
 
 
 class SyncError(Exception):
@@ -130,6 +131,9 @@ class _SyncBackend:
     def list_files(self, path: str) -> list:
         """列出远端目录下的文件名（仅顶层）。不支持时抛 NotImplementedError。"""
         raise NotImplementedError
+
+    def test_connection(self):
+        """连接后做一次真实可达性/权限探测（可选）。失败抛 SyncError。"""
 
     def close(self):
         raise NotImplementedError
@@ -466,11 +470,17 @@ class _R2Backend(_SyncBackend):
 # ─── WebDAV 后端 ───
 
 
+def _quote_path(path: str) -> str:
+    """按路径段做百分号编码，/ 保留为路径分隔符"""
+    return "/".join(quote(part, safe="") for part in path.split("/"))
+
+
 class _WebDAVBackend(_SyncBackend):
     def __init__(self, cfg):
         self.cfg = cfg
         self.base_url = ""
         self.auth_header = ""
+        self.timeout = 30
 
     def connect(self):
         url = self.cfg.get("webdav_url", "")
@@ -478,7 +488,22 @@ class _WebDAVBackend(_SyncBackend):
         password = self.cfg.get("webdav_password", "")
         if not url:
             raise SyncError("WebDAV url not configured")
-        self.base_url = url.rstrip("/")
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise SyncError("WebDAV URL 必须以 http:// 或 https:// 开头")
+        if not parsed.netloc:
+            raise SyncError("WebDAV URL 缺少主机名")
+        # 规范化 base_url 的 path：按段编码；保留 "/" 与已存在的 "%XX"，避免双重编码
+        enc_path = quote(parsed.path, safe="/%")
+        self.base_url = "%s://%s%s" % (
+            parsed.scheme,
+            parsed.netloc,
+            enc_path.rstrip("/"),
+        )
+        try:
+            self.timeout = int(self.cfg.get("webdav_timeout", 30))
+        except (TypeError, ValueError):
+            self.timeout = 30
         if user:
             import base64
 
@@ -488,7 +513,10 @@ class _WebDAVBackend(_SyncBackend):
             self.auth_header = "Basic %s" % token
 
     def _url(self, remote_path):
-        return self.base_url + "/" + remote_path.lstrip("/")
+        encoded = _quote_path(remote_path.lstrip("/"))
+        if encoded:
+            return self.base_url.rstrip("/") + "/" + encoded
+        return self.base_url.rstrip("/")
 
     def _request(self, method, url, data=None, headers=None):
         req = urllib.request.Request(url, data=data, method=method)
@@ -498,21 +526,27 @@ class _WebDAVBackend(_SyncBackend):
         if headers:
             for k, v in headers.items():
                 req.add_header(k, v)
-        return urllib.request.urlopen(req, timeout=30)
+        return urllib.request.urlopen(req, timeout=self.timeout)
 
     def ensure_remote_dir(self, path):
-        parts = [p for p in path.strip("/").split("/") if p]
-        cur = self.base_url
-        for p in parts:
-            cur += "/" + p
+        rel = ""
+        for p in [p for p in path.strip("/").split("/") if p]:
+            rel += "/" + p
+            url = self._url(rel)
             try:
-                with self._request("MKCOL", cur):
+                with self._request("MKCOL", url):
                     pass
             except urllib.error.HTTPError as e:
-                if e.code not in (405, 301):  # 405=已存在, 301=重定向到自身
-                    logger.warning("MKCOL %s -> HTTP %d", cur, e.code)
+                if e.code == 405:
+                    continue  # 标准"已存在"
+                if 300 <= e.code < 400:
+                    # 重定向：复核集合确实存在 → 幂等继续，否则判失败
+                    if self.file_exists(rel):
+                        continue
+                raise SyncError("MKCOL %s 失败: HTTP %d" % (url, e.code)) from e
             except Exception as e:
-                logger.warning("MKCOL %s failed: %s", cur, e)
+                raise SyncError("MKCOL %s 失败: %s" % (url, e)) from e
+        return True
 
     def upload_file(self, local_path, remote_path):
         try:
@@ -522,7 +556,10 @@ class _WebDAVBackend(_SyncBackend):
                     "PUT",
                     self._url(remote_path),
                     data=f,
-                    headers={"Content-Length": str(size)},
+                    headers={
+                        "Content-Length": str(size),
+                        "Content-Type": "application/octet-stream",
+                    },
                 ) as resp:
                     return 200 <= resp.status < 300
         except Exception as e:
@@ -530,14 +567,21 @@ class _WebDAVBackend(_SyncBackend):
             return False
 
     def download_file(self, remote_path, local_path):
+        tmp_path = local_path.with_suffix(local_path.suffix + ".tmp")
         try:
             local_path.parent.mkdir(parents=True, exist_ok=True)
-            with self._request("GET", self._url(remote_path)) as resp:
-                raw = resp.read()
-            with open(local_path, "wb") as f:
-                f.write(raw)
+            with self._request("GET", self._url(remote_path)) as resp, tmp_path.open(
+                "wb"
+            ) as f:
+                shutil.copyfileobj(resp, f, length=1024 * 1024)
+            os.replace(tmp_path, local_path)
             return True
         except Exception as e:
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except Exception:
+                pass
             logger.warning("download failed %s: %s", remote_path, e)
             return False
 
@@ -550,11 +594,44 @@ class _WebDAVBackend(_SyncBackend):
         except urllib.error.HTTPError as e:
             if e.code == 404:
                 return False
-            logger.warning("file_exists %s -> HTTP %d", path, e.code)
-            return False
+            if e.code in (405, 501):
+                # 服务器不支持 PROPFIND → HEAD fallback
+                try:
+                    with self._request("HEAD", self._url(path)) as resp:
+                        return resp.status in (200, 204)
+                except urllib.error.HTTPError as e2:
+                    if e2.code == 404:
+                        return False
+                    raise SyncError(
+                        "WebDAV HEAD fallback failed: HTTP %d" % e2.code
+                    ) from e2
+                except Exception as e2:
+                    raise SyncError("WebDAV HEAD fallback failed: %s" % e2) from e2
+            raise SyncError("WebDAV PROPFIND failed: HTTP %d" % e.code) from e
         except Exception as e:
-            logger.warning("file_exists %s failed: %s", path, e)
-            return False
+            raise SyncError("WebDAV file_exists failed: %s" % e) from e
+
+    def test_connection(self):
+        """真实网络探测：对 webdav_path 目录发 PROPFIND Depth:0。失败抛 SyncError。"""
+        url = self._url(self.cfg.get("webdav_path", ""))
+        try:
+            with self._request("PROPFIND", url, headers={"Depth": "0"}) as resp:
+                if resp.status not in (200, 207):
+                    raise SyncError("WebDAV PROPFIND returned HTTP %d" % resp.status)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                raise SyncError(
+                    "WebDAV 目录不存在（HTTP 404），首次上传将自动创建"
+                ) from e
+            if e.code in (401, 403):
+                raise SyncError("WebDAV 鉴权失败（HTTP %d）" % e.code) from e
+            if e.code in (405, 501):
+                raise SyncError(
+                    "WebDAV 服务器不支持 PROPFIND（HTTP %d）" % e.code
+                ) from e
+            raise SyncError("WebDAV 连接测试失败: HTTP %d" % e.code) from e
+        except (urllib.error.URLError, OSError, TimeoutError) as e:
+            raise SyncError("WebDAV 网络不可达: %s" % e) from e
 
     def delete_file(self, path):
         try:
@@ -573,11 +650,23 @@ class _WebDAVBackend(_SyncBackend):
         import xml.etree.ElementTree as ET
 
         url = self._url(path)
-        with self._request("PROPFIND", url, headers={"Depth": "1"}) as resp:
-            raw = resp.read().decode("utf-8", errors="replace")
+        try:
+            with self._request("PROPFIND", url, headers={"Depth": "1"}) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as e:
+            if e.code in (405, 501):
+                raise SyncError(
+                    "WebDAV 服务器不支持 PROPFIND（HTTP %d）" % e.code
+                ) from e
+            raise SyncError("WebDAV list_files failed: HTTP %d" % e.code) from e
+        except Exception as e:
+            raise SyncError("WebDAV list_files failed: %s" % e) from e
         base = url.rstrip("/") + "/"
         files = []
-        root = ET.fromstring(raw)
+        try:
+            root = ET.fromstring(raw)
+        except ET.ParseError as e:
+            raise SyncError("WebDAV PROPFIND 响应不是合法 XML: %s" % e) from e
         for response in root.findall("{DAV:}response"):
             href_el = response.find("{DAV:}href")
             if href_el is None or href_el.text is None:
@@ -591,6 +680,7 @@ class _WebDAVBackend(_SyncBackend):
                 name = href[len(base) :]
             else:
                 name = href.split("/")[-1]
+            name = unquote(name)
             if name:
                 files.append(name)
         return files
@@ -663,7 +753,7 @@ def _fetch_remote_memes(bk, remote_root):
 # ─── 多线程工作函数 ───
 
 
-def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
+def _push_worker(entries, remote_root, cache_dir, remote_memes):
     """单线程批量上传一批文件"""
     bk = _get_backend()
     bk.connect()
@@ -703,13 +793,6 @@ def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
                     {"filename": fname, "status": "error", "error": "上传失败"}
                 )
                 _increment_sync_progress(files_add=1)
-            thumb_file = thumb_dir / ("%s_thumb.png" % fname)
-            if thumb_file.exists():
-                rem_thumb = (
-                    remote_root.rstrip("/") + "/" + REMOTE_THUMB_DIR + "/" + fname
-                )
-                bk.ensure_remote_dir(os.path.dirname(rem_thumb))
-                bk.upload_file(thumb_file, rem_thumb)
         return local_results
     except Exception as e:
         logger.warning("push worker error: %s", e)
@@ -734,7 +817,7 @@ def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
         bk.close()
 
 
-def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
+def _pull_worker(entries, remote_root, cache_dir, db):
     """单线程批量下载一批文件"""
     bk = _get_backend()
     bk.connect()
@@ -828,10 +911,6 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
                     {"filename": fname, "status": "error", "error": "下载失败"}
                 )
                 _increment_sync_progress(files_add=1)
-            rem_thumb = remote_root.rstrip("/") + "/" + REMOTE_THUMB_DIR + "/" + fname
-            local_thumb = thumb_dir / fname
-            if bk.file_exists(rem_thumb):
-                bk.download_file(rem_thumb, local_thumb)
         return local_results
     except Exception as e:
         logger.warning("pull worker error: %s", e)
@@ -922,7 +1001,6 @@ def push(delete_remote: bool = None) -> dict:
         delete_remote = cfg.get("sync_delete_remote", False)
     remote_root = _remote_root(cfg)
     cache_dir = cfg.cache_dir
-    thumb_dir = cfg.thumbnail_dir
     max_workers = max(1, min(8, int(cfg.get("sync_threads", 3))))
     local = load_manifest()
     if not local.get("memes"):
@@ -969,9 +1047,7 @@ def push(delete_remote: bool = None) -> dict:
         }
         with ThreadPoolExecutor(max_workers=len(chunks)) as executor:
             futures = [
-                executor.submit(
-                    _push_worker, ch, remote_root, cache_dir, thumb_dir, remote_memes
-                )
+                executor.submit(_push_worker, ch, remote_root, cache_dir, remote_memes)
                 for ch in chunks
             ]
             for future in as_completed(futures):
@@ -1032,11 +1108,6 @@ def push(delete_remote: bool = None) -> dict:
                                     ),
                                 }
                             )
-                    rem_thumb = (
-                        remote_root.rstrip("/") + "/" + REMOTE_THUMB_DIR + "/" + fname
-                    )
-                    bk.delete_file(rem_thumb)
-
         build_manifest()
         remote_manifest_path = remote_root.rstrip("/") + "/" + REMOTE_INDEX
         merged_file = None
@@ -1095,6 +1166,7 @@ def sync_test() -> str:
     try:
         bk = _get_backend()
         bk.connect()
+        bk.test_connection()
         bk.close()
         return "ok"
     except Exception as e:
@@ -1161,7 +1233,7 @@ def pull(remove_local: bool = None) -> dict:
         }
         with ThreadPoolExecutor(max_workers=len(chunks)) as executor:
             futures = [
-                executor.submit(_pull_worker, ch, remote_root, cache_dir, thumb_dir, db)
+                executor.submit(_pull_worker, ch, remote_root, cache_dir, db)
                 for ch in chunks
             ]
             for future in as_completed(futures):
@@ -1299,20 +1371,20 @@ def cleanup_remote_orphans(delete: bool = False) -> dict:
 
 
 def cleanup_stale_temp_files() -> int:
-    """清理数据目录下中断遗留的临时文件（.remote-* / *.tmp），返回清理数量。"""
+    """清理中断遗留的临时文件（.remote-* / *.tmp，含 cache 目录），返回清理数量。"""
     cfg = get_config()
-    data_dir = cfg.data_dir
-    if not data_dir.exists():
-        return 0
     count = 0
-    for p in data_dir.iterdir():
-        if not p.is_file():
+    for base in (cfg.data_dir, cfg.cache_dir):
+        if not base.exists():
             continue
-        name = p.name
-        if name.startswith(".remote-") or name.endswith(".tmp"):
-            try:
-                p.unlink()
-                count += 1
-            except Exception:
-                pass
+        for p in base.iterdir():
+            if not p.is_file():
+                continue
+            name = p.name
+            if name.startswith(".remote-") or name.endswith(".tmp"):
+                try:
+                    p.unlink()
+                    count += 1
+                except Exception:
+                    pass
     return count

--- a/src/sync.py
+++ b/src/sync.py
@@ -123,6 +123,10 @@ class _SyncBackend:
     def delete_file(self, path: str) -> bool:
         raise NotImplementedError
 
+    def list_files(self, path: str) -> list:
+        """列出远端目录下的文件名（仅顶层）。不支持时抛 NotImplementedError。"""
+        raise NotImplementedError
+
     def close(self):
         raise NotImplementedError
 
@@ -208,6 +212,15 @@ class _FtpBackend(_SyncBackend):
         except Exception as e:
             logger.warning("delete failed %s: %s", path, e)
             return False
+
+    def list_files(self, path):
+        try:
+            names = []
+            self.ftp.retrlines("NLST %s" % path, names.append)
+            return [n.split("/")[-1] for n in names if n and not n.endswith("/")]
+        except Exception as e:
+            logger.warning("list_files %s failed: %s", path, e)
+            raise
 
     def close(self):
         if self.ftp is not None:
@@ -320,6 +333,25 @@ class _S3Backend(_SyncBackend):
             logger.warning("delete failed %s: %s", path, e)
             return False
 
+    def list_files(self, path):
+        prefix = self._key(path)
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+        keys = []
+        kwargs = {"Bucket": self.bucket, "Prefix": prefix}
+        while True:
+            resp = self.client.list_objects_v2(**kwargs)
+            for obj in resp.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith("/"):
+                    continue
+                keys.append(key[len(prefix) :])
+            if resp.get("IsTruncated"):
+                kwargs["ContinuationToken"] = resp.get("NextContinuationToken")
+            else:
+                break
+        return keys
+
     def close(self):
         self.client = None
 
@@ -403,6 +435,25 @@ class _R2Backend(_SyncBackend):
         except Exception as e:
             logger.warning("delete failed %s: %s", path, e)
             return False
+
+    def list_files(self, path):
+        prefix = self._key(path)
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+        keys = []
+        kwargs = {"Bucket": self.bucket, "Prefix": prefix}
+        while True:
+            resp = self.client.list_objects_v2(**kwargs)
+            for obj in resp.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith("/"):
+                    continue
+                keys.append(key[len(prefix) :])
+            if resp.get("IsTruncated"):
+                kwargs["ContinuationToken"] = resp.get("NextContinuationToken")
+            else:
+                break
+        return keys
 
     def close(self):
         self.client = None
@@ -513,6 +564,32 @@ class _WebDAVBackend(_SyncBackend):
         except Exception as e:
             logger.warning("delete failed %s: %s", path, e)
             return False
+
+    def list_files(self, path):
+        import xml.etree.ElementTree as ET
+
+        url = self._url(path)
+        with self._request("PROPFIND", url, headers={"Depth": "1"}) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+        base = url.rstrip("/") + "/"
+        files = []
+        root = ET.fromstring(raw)
+        for response in root.findall("{DAV:}response"):
+            href_el = response.find("{DAV:}href")
+            if href_el is None or href_el.text is None:
+                continue
+            href = href_el.text.strip()
+            if href.endswith("/"):
+                continue  # 目录条目跳过（仅顶层）
+            if href.rstrip("/") == url.rstrip("/"):
+                continue
+            if href.startswith(base):
+                name = href[len(base) :]
+            else:
+                name = href.split("/")[-1]
+            if name:
+                files.append(name)
+        return files
 
     def close(self):
         pass
@@ -1068,6 +1145,49 @@ def delete_all_remote() -> dict:
             pass
         return {"ok": True, "deleted": count}
     except Exception as e:
+        return {"ok": False, "error": str(e)}
+    finally:
+        bk.close()
+
+
+def list_remote_orphans(bk, remote_root) -> list:
+    """返回远端 memes/ 中真实存在但 manifest 未记录的孤儿文件名。
+
+    后端不支持 list_files 或目录不可枚举时返回 []（降级，不影响主同步）。
+    """
+    remote_path = remote_root.rstrip("/") + "/" + REMOTE_MEME_DIR
+    try:
+        remote_files = bk.list_files(remote_path)
+    except NotImplementedError:
+        return []
+    except Exception as e:
+        logger.warning("list_files %s failed: %s", remote_path, e)
+        return []
+    try:
+        remote_memes = _fetch_remote_memes(bk, remote_root)
+    except Exception as e:
+        logger.warning("list_remote_orphans fetch manifest failed: %s", e)
+        return []
+    return [fname for fname in remote_files if fname not in remote_memes]
+
+
+def cleanup_remote_orphans(delete: bool = False) -> dict:
+    """识别远端孤儿文件；delete=True 时物理删除，返回 {ok, orphans, removed}。"""
+    cfg = get_config()
+    remote_root = _remote_root(cfg)
+    bk = _get_backend()
+    bk.connect()
+    try:
+        orphans = list_remote_orphans(bk, remote_root)
+        removed = 0
+        if delete:
+            for fname in orphans:
+                rem_path = remote_root.rstrip("/") + "/" + REMOTE_MEME_DIR + "/" + fname
+                if bk.delete_file(rem_path):
+                    removed += 1
+        return {"ok": True, "orphans": orphans, "removed": removed}
+    except Exception as e:
+        logger.warning("cleanup_remote_orphans failed: %s", e)
         return {"ok": False, "error": str(e)}
     finally:
         bk.close()

--- a/src/sync.py
+++ b/src/sync.py
@@ -22,6 +22,7 @@ from .manifest import load as load_manifest
 logger = logging.getLogger(__name__)
 
 _sync_lock = threading.Lock()
+_sync_run_lock = threading.Lock()  # 防止 push/pull 并发执行
 
 # 同步进度状态（全局，供 JS 轮询）
 _sync_state = {
@@ -704,14 +705,15 @@ def _push_worker(entries, remote_root, cache_dir, thumb_dir, remote_memes):
         return local_results
     except Exception as e:
         logger.warning("push worker error: %s", e)
-        local_results["errors"] += (
-            len(entries) - local_results["uploaded"] - local_results["skipped"]
+        done = (
+            local_results["uploaded"]
+            + local_results["skipped"]
+            + local_results["errors"]
         )
-        _increment_sync_progress(
-            files_add=len(entries)
-            - local_results["uploaded"]
-            - local_results["skipped"]
-        )
+        remaining = len(entries) - done
+        if remaining > 0:
+            local_results["errors"] += remaining
+            _increment_sync_progress(files_add=remaining)
         return local_results
     finally:
         bk.close()
@@ -799,14 +801,15 @@ def _pull_worker(entries, remote_root, cache_dir, thumb_dir, db):
         return local_results
     except Exception as e:
         logger.warning("pull worker error: %s", e)
-        local_results["errors"] += (
-            len(entries) - local_results["downloaded"] - local_results["skipped"]
+        done = (
+            local_results["downloaded"]
+            + local_results["skipped"]
+            + local_results["errors"]
         )
-        _increment_sync_progress(
-            files_add=len(entries)
-            - local_results["downloaded"]
-            - local_results["skipped"]
-        )
+        remaining = len(entries) - done
+        if remaining > 0:
+            local_results["errors"] += remaining
+            _increment_sync_progress(files_add=remaining)
         return local_results
     finally:
         bk.close()
@@ -895,13 +898,17 @@ def push(delete_remote: bool = None) -> dict:
         if fp.exists():
             bytes_total += fp.stat().st_size
 
+    if not _sync_run_lock.acquire(blocking=False):
+        raise SyncError("同步正在进行中")
+
     _reset_sync_state("upload", files_total, bytes_total)
     start = time.time()
     _update_sync_state(status="uploading", start_time=start)
 
-    bk = _get_backend()
-    bk.connect()
+    bk = None
     try:
+        bk = _get_backend()
+        bk.connect()
         bk.ensure_remote_dir(remote_root)
         remote_memes = _fetch_remote_memes(bk, remote_root)
         local_idx = {m["filename"]: m for m in local["memes"]}
@@ -1012,7 +1019,9 @@ def push(delete_remote: bool = None) -> dict:
         _update_sync_state(status="error", error=str(e))
         raise
     finally:
-        bk.close()
+        if bk is not None:
+            bk.close()
+        _sync_run_lock.release()
 
 
 def sync_test() -> str:
@@ -1049,6 +1058,9 @@ def pull(remove_local: bool = None) -> dict:
     thumb_dir = cfg.thumbnail_dir
     max_workers = max(1, min(8, int(cfg.get("sync_threads", 3))))
     db = get_db()
+
+    if not _sync_run_lock.acquire(blocking=False):
+        raise SyncError("同步正在进行中")
 
     try:
         remote_data = download_index()
@@ -1133,6 +1145,8 @@ def pull(remove_local: bool = None) -> dict:
     except Exception as e:
         _update_sync_state(status="error", error=str(e))
         raise
+    finally:
+        _sync_run_lock.release()
 
 
 def delete_all_remote() -> dict:

--- a/src/webui.py
+++ b/src/webui.py
@@ -564,7 +564,11 @@ class JsApi:
             r["ok"] = True
             return r
         except Exception as e:
-            return {"ok": False, "error": str(e)}
+            return {
+                "ok": False,
+                "error": str(e),
+                "failed_files": sync_module.get_sync_progress().get("failed_items", []),
+            }
 
     def sync_pull(self) -> dict:
         try:
@@ -572,7 +576,11 @@ class JsApi:
             r["ok"] = True
             return r
         except Exception as e:
-            return {"ok": False, "error": str(e)}
+            return {
+                "ok": False,
+                "error": str(e),
+                "failed_files": sync_module.get_sync_progress().get("failed_items", []),
+            }
 
     def run_auto_sync(self) -> dict:
         """启动时自动同步：根据配置拉取远端索引和/或全量同步"""
@@ -1313,7 +1321,11 @@ class SettingsApi:
             r["ok"] = True
             return r
         except Exception as e:
-            return {"ok": False, "error": str(e)}
+            return {
+                "ok": False,
+                "error": str(e),
+                "failed_files": sync_module.get_sync_progress().get("failed_items", []),
+            }
 
     def sync_pull(self, remove_local: bool = None) -> dict:
         try:
@@ -1329,7 +1341,11 @@ class SettingsApi:
                 pass
             return r
         except Exception as e:
-            return {"ok": False, "error": str(e)}
+            return {
+                "ok": False,
+                "error": str(e),
+                "failed_files": sync_module.get_sync_progress().get("failed_items", []),
+            }
 
     def sync_test(self) -> str:
         try:

--- a/src/webui.py
+++ b/src/webui.py
@@ -1375,6 +1375,13 @@ class SettingsApi:
         except Exception as e:
             return {"ok": False, "error": str(e)}
 
+    def get_remote_orphans(self, delete: bool = False) -> dict:
+        """扫描云端孤儿文件；delete=True 时物理删除"""
+        try:
+            return sync_module.cleanup_remote_orphans(delete=delete)
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
     def check_sync_status(self) -> dict:
         """比较本地与云端同步状态"""
         try:

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -375,6 +375,12 @@ select:hover { border-color: var(--border-light); }
           <button id="btn-sync-pull" class="btn btn-primary btn-sm btn-flex" onclick="syncPull()">从远端下载</button>
         </div>
         <div id="s-sync-status" style="margin-top:6px"></div>
+        <div style="display:flex;gap:8px;margin-top:12px;align-items:center;flex-wrap:wrap">
+          <span style="font-size:12px;color:var(--muted)">云端孤儿文件</span>
+          <button id="btn-orphan-scan" class="btn btn-secondary btn-sm" onclick="scanOrphans()">扫描</button>
+          <button id="btn-orphan-delete" class="btn btn-secondary btn-sm" style="border-color:#ef4444;color:#ef4444" onclick="deleteOrphans()" disabled>删除孤儿</button>
+          <span id="s-orphan-status" style="font-size:11.5px;color:var(--muted)"></span>
+        </div>
       </div>
     </div>
 
@@ -871,6 +877,37 @@ async function checkSyncStatus() {
   if (r.local_missing > 0) msg += '，本地缺少 ' + r.local_missing + ' 个';
   status.textContent = msg;
   showToast('同步状态：' + msg);
+}
+
+let _orphanFiles = [];
+
+async function scanOrphans() {
+  const status = document.getElementById('s-orphan-status');
+  const del = document.getElementById('btn-orphan-delete');
+  status.textContent = '扫描中...';
+  const r = await api('get_remote_orphans', false);
+  if (!r || !r.ok) {
+    status.textContent = '扫描失败: ' + ((r && r.error) || '未知错误');
+    return;
+  }
+  _orphanFiles = r.orphans || [];
+  status.textContent = _orphanFiles.length
+    ? '发现 ' + _orphanFiles.length + ' 个孤儿文件'
+    : '无孤儿文件';
+  del.disabled = _orphanFiles.length === 0;
+}
+
+async function deleteOrphans() {
+  if (!_orphanFiles.length) return;
+  const status = document.getElementById('s-orphan-status');
+  const r = await api('get_remote_orphans', true);
+  if (!r || !r.ok) {
+    status.textContent = '删除失败: ' + ((r && r.error) || '未知错误');
+    return;
+  }
+  status.textContent = '已删除 ' + r.removed + ' 个孤儿文件';
+  _orphanFiles = [];
+  document.getElementById('btn-orphan-delete').disabled = true;
 }
 
 async function showUploadWarning() {

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -1023,7 +1023,22 @@ async function doSyncWithProgress(method, title, progressSetting, doneSetting, b
       document.getElementById('sync-done-overlay').style.display = 'flex';
     }
   } else {
-    status.textContent = '失败: ' + ((r && r.error) || '未知错误');
+    let msg = '失败: ' + ((r && r.error) || '未知错误');
+    const ff = (r && r.failed_files) || [];
+    if (ff.length) {
+      const errors = ff.filter(f => f.status !== 'unknown');
+      const unknowns = ff.filter(f => f.status === 'unknown');
+      const parts = [];
+      if (errors.length) {
+        const names = errors.slice(0, 5).map(f => f.filename || '?').join(', ');
+        parts.push('失败 ' + errors.length + ' 个: ' + names);
+      }
+      if (unknowns.length) {
+        parts.push(unknowns.length + ' 个删除结果不确定，将在下次同步时复核');
+      }
+      msg += '（' + parts.join('；') + '）';
+    }
+    status.textContent = msg;
   }
 
   // 刷新主窗口

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 """OhMyMeme 核心模块测试"""
 
-import os
 import re
 import sys
 import tempfile
@@ -10,10 +9,10 @@ from pathlib import Path
 # 确保 src 在导入路径中
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from src import __version__, __app_name__
+from src import __app_name__, __version__
 from src.config import Config
+from src.crypto_util import decrypt_data, encrypt_data
 from src.database import MemeDB
-from src.crypto_util import encrypt_data, decrypt_data
 
 
 class TestVersion(unittest.TestCase):
@@ -45,6 +44,7 @@ class TestConfig(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def test_defaults(self):
@@ -94,6 +94,7 @@ class TestDatabase(unittest.TestCase):
     def tearDown(self):
         self.db.close()
         import shutil
+
         shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def test_add_meme(self):

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -7,12 +7,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 os.environ["OHMYMEME_TEST"] = "1"
 
+from src.clipboard_util import copy_image_to_clipboard, copy_text
 from src.config import Config
+from src.crypto_util import decrypt_data, encrypt_data
 from src.database import MemeDB
 from src.hotkey import GlobalHotkey
 from src.tray import _create_default_icon
-from src.clipboard_util import copy_image_to_clipboard, copy_text
-from src.crypto_util import encrypt_data, decrypt_data
 
 
 def test_config_io(tmp_path):
@@ -25,7 +25,7 @@ def test_config_io(tmp_path):
     cfg2 = Config(tmp_path / "config.json")
     assert cfg2.get("hotkey") == "Ctrl+Shift+X"
     assert cfg2.get("s3_secret_key") == "test_secret_123"
-    assert cfg2.get("auto_start") == True
+    assert cfg2.get("auto_start")
 
 
 def test_database_operations(tmp_path):
@@ -47,7 +47,7 @@ def test_database_operations(tmp_path):
 def test_hotkey_init():
     hk = GlobalHotkey()
     result = hk.register("Ctrl+Alt+N", lambda: None)
-    assert result == True
+    assert result
     hk.unregister()
 
 
@@ -56,6 +56,7 @@ def test_tray_icon():
     assert img is not None
     assert img.size == (64, 64)
     import io
+
     buf = io.BytesIO()
     img.save(buf, format="PNG")
     assert len(buf.getvalue()) > 0
@@ -72,18 +73,21 @@ def test_crypto():
 def test_clipboard():
     result = copy_text("test")
     assert isinstance(result, bool)
-    icon_path = Path(__file__).resolve().parent.parent / "src" / "resources" / "icon.png"
+    icon_path = (
+        Path(__file__).resolve().parent.parent / "src" / "resources" / "icon.png"
+    )
     if icon_path.exists():
         result = copy_image_to_clipboard(str(icon_path))
         assert isinstance(result, bool)
 
 
 def test_webui_import():
-    from src.webui import WebUI, JsApi
+    from src.webui import JsApi, WebUI
+
     w = WebUI()
     assert w._port > 0
     assert w._window is None
-    assert w.is_visible == False
+    assert not w.is_visible
     assert hasattr(w, "toggle_safe")
     assert hasattr(w, "show")
     assert hasattr(w, "hide")
@@ -97,6 +101,7 @@ def test_webui_import():
 
 def test_webui_html_exists():
     from src.webui import HTML_DIR
+
     assert HTML_DIR.exists()
     assert (HTML_DIR / "index.html").exists()
     html = (HTML_DIR / "index.html").read_text(encoding="utf-8")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -535,6 +535,16 @@ class TestSyncPush(unittest.TestCase):
         self.assertFalse((self.data_dir / "meme-index.json.tmp").exists())
         self.assertTrue((self.data_dir / "meme-index.json").exists())
 
+    def test_cleanup_stale_temp_files_covers_cache(self):
+        """启动清理：cache 子目录下的 *.tmp 也被清理"""
+        cache = self.data_dir / "cache"
+        (cache / "abc.png.tmp").write_text("x")
+        from src.sync import cleanup_stale_temp_files
+
+        count = cleanup_stale_temp_files()
+        self.assertGreaterEqual(count, 1)
+        self.assertFalse((cache / "abc.png.tmp").exists())
+
     def test_download_index_leaves_no_temp(self):
         """download_index 使用唯一临时文件且结束后清理，无残留"""
         self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -371,12 +371,15 @@ class TestSyncPush(unittest.TestCase):
         self.assertIn("ghost.png", self._manifest_filenames())
 
     def test_push_manifest_failure_cleans_temp_merged(self):
-        """manifest 上传失败时 .remote-merged.json 被清理，不残留"""
+        """manifest 上传失败时合并临时文件被清理，不残留"""
         self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
         self.fake_backend.manifest_ok = False
         with self.assertRaises(SyncError):
             sync.push()
-        self.assertFalse((self.data_dir / ".remote-merged.json").exists())
+        leftovers = [
+            p for p in self.data_dir.iterdir() if p.name.startswith(".remote-merged-")
+        ]
+        self.assertEqual(leftovers, [])
 
     # ─── PR2 新增用例 ───
 
@@ -511,6 +514,44 @@ class TestSyncPush(unittest.TestCase):
             result = cleanup_remote_orphans(delete=False)
         self.assertTrue(result["ok"])
         self.assertEqual(result["orphans"], [])
+
+    # ─── PR5 新增用例 ───
+
+    def test_cleanup_stale_temp_files(self):
+        """启动清理：删除中断遗留临时文件，保留正式清单"""
+        (self.data_dir / ".remote-index-abc.json").write_text("x")
+        (self.data_dir / ".remote-merged-def.json").write_text("x")
+        (self.data_dir / "meme-index.json.tmp").write_text("x")
+        from src.sync import cleanup_stale_temp_files
+
+        count = cleanup_stale_temp_files()
+        self.assertEqual(count, 3)
+        self.assertFalse((self.data_dir / ".remote-index-abc.json").exists())
+        self.assertFalse((self.data_dir / ".remote-merged-def.json").exists())
+        self.assertFalse((self.data_dir / "meme-index.json.tmp").exists())
+        self.assertTrue((self.data_dir / "meme-index.json").exists())
+
+    def test_download_index_leaves_no_temp(self):
+        """download_index 使用唯一临时文件且结束后清理，无残留"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        from src.sync import download_index
+
+        data = download_index()
+        self.assertIsNotNone(data)
+        leftovers = [
+            p for p in self.data_dir.iterdir() if p.name.startswith(".remote-")
+        ]
+        self.assertEqual(leftovers, [])
+
+    def test_fetch_remote_memes_download_failure_leaves_no_temp(self):
+        """远端 manifest 存在但下载失败 → 无 .remote-index-* 残留"""
+        self.fake_backend.manifest_download_ok = False
+        with self.assertRaises(SyncError):
+            sync.push()
+        leftovers = [
+            p for p in self.data_dir.iterdir() if p.name.startswith(".remote-index-")
+        ]
+        self.assertEqual(leftovers, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -450,6 +450,33 @@ class TestSyncPush(unittest.TestCase):
         after = json.loads((self.data_dir / INDEX_FILENAME).read_text(encoding="utf-8"))
         self.assertEqual(after, old)
 
+    # ─── PR3 新增用例 ───
+
+    def test_push_skips_consistent_remote_file(self):
+        """远端真实存在且 hash 一致 → 跳过"""
+        self.fake_backend.remote_memes = {"test.png": _entry("test.png", "abc")}
+        result = sync.push()
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(result["uploaded"], 0)
+
+    def test_push_reuploads_when_remote_file_missing(self):
+        """远端清单声称一致但真实文件缺失 → push 重新上传（污染自愈）"""
+        # 远端清单有 test.png(同hash)，但物理文件缺失
+        self.fake_backend.remote_memes = {"test.png": _entry("test.png", "abc")}
+        self.fake_backend.remote_files = set()  # 物理缺失
+        result = sync.push()
+        self.assertEqual(result["uploaded"], 1)  # 重新上传而非 skip
+        self.assertEqual(result["skipped"], 0)
+        self.assertIn("test.png", self.fake_backend.remote_files)  # 已补传
+
+    def test_push_reuploads_when_existence_check_fails(self):
+        """file_exists 复核异常 → 保守重传（不依赖污染清单）"""
+        self.fake_backend.remote_memes = {"test.png": _entry("test.png", "abc")}
+        self.fake_backend.raise_on_exists.add("test.png")
+        result = sync.push()
+        self.assertEqual(result["uploaded"], 1)
+        self.assertEqual(result["skipped"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -612,6 +612,52 @@ class TestSyncPush(unittest.TestCase):
         result = sync.push()
         self.assertEqual(result["uploaded"], 1)
 
+    # ─── PR8 新增用例 ───
+
+    def test_push_failed_items_reported(self):
+        """push 上传失败 → _sync_state.failed_items 记录失败文件"""
+        self._set_local_memes(
+            [
+                {"filename": "a.png", "sha256": "a"},
+                {"filename": "b.png", "sha256": "b"},
+            ]
+        )
+        self.fake_backend.meme_ok = False
+        with self.assertRaises(SyncError):
+            sync.push()
+        failed = get_sync_progress().get("failed_items", [])
+        self.assertEqual(len(failed), 2)
+        for item in failed:
+            self.assertEqual(item["status"], "error")
+            self.assertIn(item["filename"], {"a.png", "b.png"})
+
+    def test_push_delete_unknown_reported(self):
+        """delete_remote=True 删除复核异常 → failed_files 记录 unknown 状态"""
+        self.fake_backend.remote_memes = {"ghost.png": _entry("ghost.png", "x")}
+        self.fake_backend.delete_ok = False
+        self.fake_backend.raise_on_exists.add("ghost.png")
+        self.cfg.set("sync_delete_remote", True)
+        result = sync.push()
+        unknowns = [
+            f for f in result.get("failed_files", []) if f["status"] == "unknown"
+        ]
+        self.assertEqual(len(unknowns), 1)
+        self.assertEqual(unknowns[0]["filename"], "ghost.png")
+
+    def test_pull_failed_items_reported(self):
+        """pull 部分下载失败 → _sync_state.failed_items 记录失败文件"""
+        self.fake_backend.remote_memes = {
+            "test.png": _entry("test.png", "abc"),
+            "missing.png": _entry("missing.png", "x"),
+        }
+        self.fake_backend.remote_files = {"test.png"}
+        with self.assertRaises(SyncError):
+            sync.pull()
+        failed = get_sync_progress().get("failed_items", [])
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["filename"], "missing.png")
+        self.assertEqual(failed[0]["status"], "error")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -25,7 +25,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from src import sync
 from src.config import Config
 from src.manifest import INDEX_FILENAME
-from src.sync import SyncError, get_sync_progress
+from src.sync import SyncError, cleanup_remote_orphans, get_sync_progress
 
 
 def _entry(fname, sha256, size=1):
@@ -58,6 +58,7 @@ class _FakeBackend:
         self.manifest_content = None  # 覆盖 manifest 下载内容（可注入损坏 JSON）
         self.empty_downloads = set()  # 下载后为空的文件
         self.download_paths = []
+        self.list_calls = []
 
     @property
     def remote_memes(self):
@@ -133,6 +134,10 @@ class _FakeBackend:
             return False
         self.remote_files.discard(self._basename(path))
         return True
+
+    def list_files(self, path):
+        self.list_calls.append(str(path))
+        return sorted(self.remote_files)
 
     def close(self):
         pass
@@ -476,6 +481,36 @@ class TestSyncPush(unittest.TestCase):
         result = sync.push()
         self.assertEqual(result["uploaded"], 1)
         self.assertEqual(result["skipped"], 0)
+
+    # ─── PR4 新增用例 ───
+
+    def test_cleanup_remote_orphans_lists(self):
+        """远端真实文件多于清单 → 识别孤儿（不删除）"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        self.fake_backend.remote_files.add("orphan.png")  # 真实存在但清单无记录
+        result = cleanup_remote_orphans(delete=False)
+        self.assertTrue(result["ok"])
+        self.assertIn("orphan.png", result["orphans"])
+        self.assertNotIn("a.png", result["orphans"])
+
+    def test_cleanup_remote_orphans_deletes(self):
+        """清理孤儿：delete=True 删除真实孤儿文件"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        self.fake_backend.remote_files.add("orphan.png")
+        result = cleanup_remote_orphans(delete=True)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["removed"], 1)
+        self.assertNotIn("orphan.png", self.fake_backend.remote_files)
+
+    def test_cleanup_remote_orphans_degraded(self):
+        """后端无 list_files → 降级返回空孤儿，不影响主同步"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        with patch.object(
+            self.fake_backend, "list_files", side_effect=NotImplementedError
+        ):
+            result = cleanup_remote_orphans(delete=False)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["orphans"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,9 +1,12 @@
 """sync.push() 远端 manifest 一致性回归测试
 
-覆盖 push() 的止血修复：
+覆盖 push() 的修复：
 - 任一普通图片上传失败 → 抛 SyncError，且不上传新的远端 manifest
 - manifest 上传失败 → 抛 SyncError
-- 全部上传成功 → 正常返回并置 done 状态
+- 上传失败不删除远端文件
+- delete_remote=False 时远端仍保留的文件合并进远端 manifest（避免孤儿）
+- 删除失败 / 删除结果未知(unknown) 的远端文件保留在 manifest
+- 合并用临时文件，上传后清理，本地 meme-index.json 不被污染
 
 使用 FakeBackend 替换真实 FTP/S3/R2/WebDAV，不访问网络。
 """
@@ -25,15 +28,49 @@ from src.manifest import INDEX_FILENAME
 from src.sync import SyncError, get_sync_progress
 
 
+def _entry(fname, sha256, size=1):
+    return {
+        "filename": fname,
+        "name": fname,
+        "sha256": sha256,
+        "file_size": size,
+        "mtime": "",
+    }
+
+
 class _FakeBackend:
-    """内存假后端：只记录上传路径，可按需让 meme/manifest 上传失败"""
+    """内存假后端：记录上传/删除与 manifest 载荷，可配置各操作成败"""
 
     def __init__(self, meme_ok=True, manifest_ok=True, remote_memes=None):
         self.meme_ok = meme_ok
         self.manifest_ok = manifest_ok
-        self.remote_memes = remote_memes or {}
+        self._remote_memes = {}
+        self.remote_files = set()
+        self.remote_memes = remote_memes or {}  # setter 同步 remote_files
         self.upload_paths = []
         self.delete_calls = []
+        self.manifest_payload = None
+        self.delete_ok = True
+        self.exists_overrides = {}  # filename -> bool
+        self.raise_on_exists = set()  # filename -> 抛异常(unknown)
+        self.manifest_exists = True  # 远端 manifest 是否存在
+        self.manifest_download_ok = True  # manifest 下载是否成功
+        self.manifest_content = None  # 覆盖 manifest 下载内容（可注入损坏 JSON）
+        self.empty_downloads = set()  # 下载后为空的文件
+        self.download_paths = []
+
+    @property
+    def remote_memes(self):
+        return self._remote_memes
+
+    @remote_memes.setter
+    def remote_memes(self, value):
+        self._remote_memes = value or {}
+        self.remote_files = set(self._remote_memes.keys())
+
+    @staticmethod
+    def _basename(path):
+        return str(path).rsplit("/", 1)[-1]
 
     def connect(self):
         pass
@@ -42,24 +79,59 @@ class _FakeBackend:
         pass
 
     def file_exists(self, path):
-        # 远端 manifest 存在 → 让 _fetch_remote_memes 走下载分支
-        return str(path).endswith(INDEX_FILENAME)
+        if str(path).endswith(INDEX_FILENAME):
+            return self.manifest_exists
+        fname = self._basename(path)
+        if fname in self.raise_on_exists:
+            raise RuntimeError("file_exists timeout")
+        if fname in self.exists_overrides:
+            return self.exists_overrides[fname]
+        return fname in self.remote_files
 
     def download_file(self, remote_path, local_path):
-        if str(remote_path).endswith(INDEX_FILENAME):
-            data = {"version": 3, "memes": list(self.remote_memes.values())}
-            Path(local_path).write_text(json.dumps(data))
+        rp = str(remote_path)
+        self.download_paths.append(rp)
+        if rp.endswith(INDEX_FILENAME):
+            if not self.manifest_download_ok:
+                return False
+            if self.manifest_content is None:
+                content = json.dumps(
+                    {"version": 3, "memes": list(self.remote_memes.values())}
+                )
+            else:
+                content = self.manifest_content
+            Path(local_path).write_text(content)
             return True
-        return False
+        fname = self._basename(rp)
+        if fname not in self.remote_files:
+            return False
+        if fname in self.empty_downloads:
+            Path(local_path).write_bytes(b"")
+        else:
+            Path(local_path).write_bytes(b"fake image content")
+        return True
 
     def upload_file(self, local_path, remote_path):
-        self.upload_paths.append(str(remote_path))
-        if str(remote_path).endswith(INDEX_FILENAME):
+        rp = str(remote_path)
+        self.upload_paths.append(rp)
+        if rp.endswith(INDEX_FILENAME):
+            if self.manifest_ok:
+                try:
+                    self.manifest_payload = json.loads(
+                        Path(local_path).read_text(encoding="utf-8")
+                    )
+                except Exception:
+                    self.manifest_payload = None
             return self.manifest_ok
+        if self.meme_ok:
+            self.remote_files.add(self._basename(rp))
         return self.meme_ok
 
     def delete_file(self, path):
         self.delete_calls.append(str(path))
+        if not self.delete_ok:
+            return False
+        self.remote_files.discard(self._basename(path))
         return True
 
     def close(self):
@@ -69,18 +141,62 @@ class _FakeBackend:
 class _FakeDb:
     """build_manifest() 所需的假数据库，避免触碰真实数据"""
 
+    def __init__(self, rows=None):
+        self.rows = (
+            list(rows)
+            if rows
+            else [
+                {
+                    "filename": "test.png",
+                    "original_name": "test",
+                    "file_hash": "abc",
+                    "file_size": 16,
+                }
+            ]
+        )
+
     def search(self, keyword="", tags=None, limit=999999, collection_id=None):
-        return [
-            {
-                "filename": "test.png",
-                "original_name": "test",
-                "file_hash": "abc",
-                "file_size": 16,
-            }
-        ]
+        return list(self.rows)
 
     def get_collections(self):
         return []
+
+    def get_by_filename(self, filename):
+        for r in self.rows:
+            if r["filename"] == filename:
+                return dict(r)
+        return None
+
+    def add_meme(
+        self,
+        filename,
+        file_hash="",
+        width=0,
+        height=0,
+        file_size=0,
+        mime_type="image/png",
+        original_name="",
+        tags=None,
+    ):
+        self.rows.append(
+            {
+                "filename": filename,
+                "original_name": original_name,
+                "file_hash": file_hash,
+                "file_size": file_size,
+            }
+        )
+        return len(self.rows)
+
+    def delete_meme(self, meme_id):
+        if 0 < meme_id <= len(self.rows):
+            del self.rows[meme_id - 1]
+
+    def create_collection(self, name, parent_id=None):
+        return 1
+
+    def add_to_collection(self, meme_id, collection_id):
+        pass
 
 
 class TestSyncPush(unittest.TestCase):
@@ -90,28 +206,11 @@ class TestSyncPush(unittest.TestCase):
         self.tmp_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
 
-        # 临时数据目录：cache 里有图片文件，data 里有本地 manifest
         self.data_dir = self.tmp_dir / "data"
         cache_dir = self.data_dir / "cache"
         thumb_dir = self.data_dir / "thumbnails"
         cache_dir.mkdir(parents=True, exist_ok=True)
         thumb_dir.mkdir(parents=True, exist_ok=True)
-        (cache_dir / "test.png").write_bytes(b"fake image bytes")
-
-        manifest = {
-            "version": 3,
-            "memes": [
-                {
-                    "filename": "test.png",
-                    "name": "test",
-                    "sha256": "abc",
-                    "file_size": 16,
-                    "mtime": "",
-                }
-            ],
-            "collections": [],
-        }
-        (self.data_dir / INDEX_FILENAME).write_text(json.dumps(manifest))
 
         self.cfg = Config(self.tmp_dir / "config.json")
         self.cfg.set("sync_type", "ftp")
@@ -121,16 +220,58 @@ class TestSyncPush(unittest.TestCase):
         self._start_patch(patch("src.config._get_data_dir", return_value=self.data_dir))
         for target in ("src.sync.get_config", "src.manifest.get_config"):
             self._start_patch(patch(target, return_value=self.cfg))
-        self._start_patch(patch("src.manifest.get_db", return_value=_FakeDb()))
+        self.fake_db = _FakeDb()
+        self._start_patch(patch("src.manifest.get_db", return_value=self.fake_db))
+        self._start_patch(patch("src.sync.get_db", return_value=self.fake_db))
 
         self.fake_backend = _FakeBackend()
         self._start_patch(
             patch("src.sync._get_backend", return_value=self.fake_backend)
         )
 
+        # 默认一个本地文件 test.png
+        self._set_local_memes([{"filename": "test.png", "sha256": "abc"}])
+
     def _start_patch(self, patcher):
         patcher.start()
         self.addCleanup(patcher.stop)
+
+    def _set_local_memes(self, memes):
+        """设置本地 memes（同步本地清单 / cache 文件 / FakeDb）"""
+        manifest = {
+            "version": 3,
+            "memes": [
+                {
+                    "filename": m["filename"],
+                    "name": m["filename"],
+                    "sha256": m["sha256"],
+                    "file_size": m.get("file_size", 8),
+                    "mtime": "",
+                }
+                for m in memes
+            ],
+            "collections": [],
+        }
+        (self.data_dir / INDEX_FILENAME).write_text(json.dumps(manifest))
+        for m in memes:
+            fp = self.data_dir / "cache" / m["filename"]
+            if not fp.exists():
+                fp.write_bytes(b"x" * int(m.get("file_size", 8)))
+        self.fake_db.rows = [
+            {
+                "filename": m["filename"],
+                "original_name": m["filename"],
+                "file_hash": m["sha256"],
+                "file_size": m.get("file_size", 8),
+            }
+            for m in memes
+        ]
+
+    def _manifest_filenames(self):
+        self.assertIsNotNone(self.fake_backend.manifest_payload)
+        return {m["filename"] for m in self.fake_backend.manifest_payload["memes"]}
+
+    # ─── 既有用例（止血修复） ───
 
     def test_meme_upload_failure_aborts_manifest(self):
         """普通图片上传失败时：抛 SyncError、不上传 manifest、状态为 error"""
@@ -157,14 +298,7 @@ class TestSyncPush(unittest.TestCase):
     def test_delete_remote_not_called_on_error(self):
         """delete_remote=True 且图片上传失败时：不删除任何远端文件"""
         self.fake_backend.meme_ok = False
-        self.fake_backend.remote_memes = {
-            "ghost.png": {
-                "filename": "ghost.png",
-                "sha256": "x",
-                "file_size": 1,
-                "mtime": "",
-            }
-        }
+        self.fake_backend.remote_memes = {"ghost.png": _entry("ghost.png", "x")}
         self.cfg.set("sync_delete_remote", True)
         with self.assertRaises(SyncError):
             sync.push()
@@ -179,6 +313,142 @@ class TestSyncPush(unittest.TestCase):
             any(p.endswith(INDEX_FILENAME) for p in self.fake_backend.upload_paths)
         )
         self.assertEqual(get_sync_progress()["status"], "done")
+
+    # ─── PR1 新增用例 ───
+
+    def test_push_keeps_remote_only_files_in_manifest(self):
+        """远端 A,B 本地 B,C，push(delete_remote=False) → 远端 manifest=A,B,C"""
+        self._set_local_memes(
+            [
+                {"filename": "b.png", "sha256": "abc"},
+                {"filename": "c.png", "sha256": "def"},
+            ]
+        )
+        self.fake_backend.remote_memes = {
+            "a.png": _entry("a.png", "x"),
+            "b.png": _entry("b.png", "abc"),
+        }
+        result = sync.push()
+        self.assertEqual(result["uploaded"], 1)  # c.png
+        self.assertEqual(result["skipped"], 1)  # b.png
+        self.assertEqual(self._manifest_filenames(), {"a.png", "b.png", "c.png"})
+        # 本地 meme-index.json 未被污染：仍只含本地文件
+        local = json.loads((self.data_dir / INDEX_FILENAME).read_text(encoding="utf-8"))
+        self.assertEqual({m["filename"] for m in local["memes"]}, {"b.png", "c.png"})
+
+    def test_push_delete_failure_keeps_remote_in_manifest(self):
+        """delete_remote=True 且删除失败（复核仍在）→ 远端 manifest 保留该文件"""
+        self.fake_backend.remote_memes = {"ghost.png": _entry("ghost.png", "x")}
+        self.fake_backend.delete_ok = False
+        self.fake_backend.exists_overrides["ghost.png"] = True
+        self.cfg.set("sync_delete_remote", True)
+        result = sync.push()
+        self.assertIn("ghost.png", self._manifest_filenames())
+        self.assertEqual(result["deleted"], 0)
+
+    def test_push_delete_verified_absent_counts_deleted(self):
+        """删除返回 False 但复核确认已删 → 计 deleted、不进 manifest"""
+        self.fake_backend.remote_memes = {"ghost.png": _entry("ghost.png", "x")}
+        self.fake_backend.delete_ok = False
+        self.fake_backend.exists_overrides["ghost.png"] = False
+        self.cfg.set("sync_delete_remote", True)
+        result = sync.push()
+        self.assertNotIn("ghost.png", self._manifest_filenames())
+        self.assertEqual(result["deleted"], 1)
+
+    def test_push_delete_unknown_keeps_remote_in_manifest(self):
+        """删除复核异常(unknown) → 保留在远端 manifest，等待下次重查"""
+        self.fake_backend.remote_memes = {"ghost.png": _entry("ghost.png", "x")}
+        self.fake_backend.delete_ok = False
+        self.fake_backend.raise_on_exists.add("ghost.png")
+        self.cfg.set("sync_delete_remote", True)
+        sync.push()
+        self.assertIn("ghost.png", self._manifest_filenames())
+
+    def test_push_manifest_failure_cleans_temp_merged(self):
+        """manifest 上传失败时 .remote-merged.json 被清理，不残留"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        self.fake_backend.manifest_ok = False
+        with self.assertRaises(SyncError):
+            sync.push()
+        self.assertFalse((self.data_dir / ".remote-merged.json").exists())
+
+    # ─── PR2 新增用例 ───
+
+    def test_pull_partial_failure_raises(self):
+        """pull 部分下载失败 → 抛 SyncError、status=error、本地清单不含失败项"""
+        self.fake_backend.remote_memes = {
+            "test.png": _entry("test.png", "abc"),
+            "missing.png": _entry("missing.png", "x"),
+        }
+        self.fake_backend.remote_files = {"test.png"}  # missing.png 物理缺失
+        with self.assertRaises(SyncError) as ctx:
+            sync.pull()
+        self.assertIn("下载失败", str(ctx.exception))
+        self.assertEqual(get_sync_progress()["status"], "error")
+        local = json.loads((self.data_dir / INDEX_FILENAME).read_text(encoding="utf-8"))
+        self.assertNotIn("missing.png", {m["filename"] for m in local["memes"]})
+
+    def test_pull_re_downloads_missing_local_cache(self):
+        """本地清单有记录但 cache 缺失 → pull 重新下载"""
+        (self.data_dir / "cache" / "test.png").unlink()
+        self.fake_backend.remote_memes = {"test.png": _entry("test.png", "abc")}
+        result = sync.pull()
+        self.assertEqual(result["downloaded"], 1)
+        self.assertEqual(result["errors"], 0)
+        self.assertTrue((self.data_dir / "cache" / "test.png").exists())
+
+    def test_pull_manifest_corrupted_raises(self):
+        """远端 manifest 损坏 JSON → pull 抛 SyncError，不做文件操作"""
+        self.fake_backend.manifest_content = "{ this is not json"
+        with self.assertRaises(SyncError):
+            sync.pull()
+        self.assertFalse(
+            any(
+                not p.endswith(INDEX_FILENAME) for p in self.fake_backend.download_paths
+            )
+        )
+
+    def test_push_manifest_corrupted_raises(self):
+        """远端 manifest 损坏 JSON → push 抛 SyncError，不上传任何文件"""
+        self.fake_backend.manifest_content = "{ this is not json"
+        with self.assertRaises(SyncError):
+            sync.push()
+        self.assertEqual(self.fake_backend.upload_paths, [])
+
+    def test_push_no_remote_manifest_first_sync(self):
+        """首次同步（远端无 manifest）→ push 正常上传全部本地文件"""
+        self.fake_backend.manifest_exists = False
+        result = sync.push()
+        self.assertEqual(result["uploaded"], 1)
+        self.assertEqual(get_sync_progress()["status"], "done")
+
+    def test_push_manifest_download_failure_raises(self):
+        """远端 manifest 存在但下载失败 → push 抛 SyncError（区分于首次同步）"""
+        self.fake_backend.manifest_download_ok = False
+        with self.assertRaises(SyncError):
+            sync.push()
+        self.assertEqual(self.fake_backend.upload_paths, [])
+
+    def test_pull_empty_download_counts_error(self):
+        """远端下载到空文件 → 计 error，不入本地 manifest"""
+        self.fake_backend.remote_memes = {"empty.png": _entry("empty.png", "x")}
+        self.fake_backend.empty_downloads.add("empty.png")
+        with self.assertRaises(SyncError):
+            sync.pull()
+        self.assertEqual(get_sync_progress()["status"], "error")
+        local = json.loads((self.data_dir / INDEX_FILENAME).read_text(encoding="utf-8"))
+        self.assertNotIn("empty.png", {m["filename"] for m in local["memes"]})
+
+    def test_build_manifest_atomic_replace_preserves_old_on_failure(self):
+        """build_manifest 原子替换：os.replace 失败时旧清单完好"""
+        old = json.loads((self.data_dir / INDEX_FILENAME).read_text(encoding="utf-8"))
+        with patch("src.manifest.os.replace", side_effect=OSError("disk full")):
+            from src.manifest import build as _build
+
+            _build()
+        after = json.loads((self.data_dir / INDEX_FILENAME).read_text(encoding="utf-8"))
+        self.assertEqual(after, old)
 
 
 if __name__ == "__main__":

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,185 @@
+"""sync.push() 远端 manifest 一致性回归测试
+
+覆盖 push() 的止血修复：
+- 任一普通图片上传失败 → 抛 SyncError，且不上传新的远端 manifest
+- manifest 上传失败 → 抛 SyncError
+- 全部上传成功 → 正常返回并置 done 状态
+
+使用 FakeBackend 替换真实 FTP/S3/R2/WebDAV，不访问网络。
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# 确保 src 在导入路径中
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src import sync
+from src.config import Config
+from src.manifest import INDEX_FILENAME
+from src.sync import SyncError, get_sync_progress
+
+
+class _FakeBackend:
+    """内存假后端：只记录上传路径，可按需让 meme/manifest 上传失败"""
+
+    def __init__(self, meme_ok=True, manifest_ok=True, remote_memes=None):
+        self.meme_ok = meme_ok
+        self.manifest_ok = manifest_ok
+        self.remote_memes = remote_memes or {}
+        self.upload_paths = []
+        self.delete_calls = []
+
+    def connect(self):
+        pass
+
+    def ensure_remote_dir(self, path):
+        pass
+
+    def file_exists(self, path):
+        # 远端 manifest 存在 → 让 _fetch_remote_memes 走下载分支
+        return str(path).endswith(INDEX_FILENAME)
+
+    def download_file(self, remote_path, local_path):
+        if str(remote_path).endswith(INDEX_FILENAME):
+            data = {"version": 3, "memes": list(self.remote_memes.values())}
+            Path(local_path).write_text(json.dumps(data))
+            return True
+        return False
+
+    def upload_file(self, local_path, remote_path):
+        self.upload_paths.append(str(remote_path))
+        if str(remote_path).endswith(INDEX_FILENAME):
+            return self.manifest_ok
+        return self.meme_ok
+
+    def delete_file(self, path):
+        self.delete_calls.append(str(path))
+        return True
+
+    def close(self):
+        pass
+
+
+class _FakeDb:
+    """build_manifest() 所需的假数据库，避免触碰真实数据"""
+
+    def search(self, keyword="", tags=None, limit=999999, collection_id=None):
+        return [
+            {
+                "filename": "test.png",
+                "original_name": "test",
+                "file_hash": "abc",
+                "file_size": 16,
+            }
+        ]
+
+    def get_collections(self):
+        return []
+
+
+class TestSyncPush(unittest.TestCase):
+    """push() manifest 一致性回归测试"""
+
+    def setUp(self):
+        self.tmp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+
+        # 临时数据目录：cache 里有图片文件，data 里有本地 manifest
+        self.data_dir = self.tmp_dir / "data"
+        cache_dir = self.data_dir / "cache"
+        thumb_dir = self.data_dir / "thumbnails"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        thumb_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "test.png").write_bytes(b"fake image bytes")
+
+        manifest = {
+            "version": 3,
+            "memes": [
+                {
+                    "filename": "test.png",
+                    "name": "test",
+                    "sha256": "abc",
+                    "file_size": 16,
+                    "mtime": "",
+                }
+            ],
+            "collections": [],
+        }
+        (self.data_dir / INDEX_FILENAME).write_text(json.dumps(manifest))
+
+        self.cfg = Config(self.tmp_dir / "config.json")
+        self.cfg.set("sync_type", "ftp")
+        self.cfg.set("sync_threads", 1)
+
+        # 将 data_dir / get_config / get_db / _get_backend 全部指向临时环境
+        self._start_patch(patch("src.config._get_data_dir", return_value=self.data_dir))
+        for target in ("src.sync.get_config", "src.manifest.get_config"):
+            self._start_patch(patch(target, return_value=self.cfg))
+        self._start_patch(patch("src.manifest.get_db", return_value=_FakeDb()))
+
+        self.fake_backend = _FakeBackend()
+        self._start_patch(
+            patch("src.sync._get_backend", return_value=self.fake_backend)
+        )
+
+    def _start_patch(self, patcher):
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_meme_upload_failure_aborts_manifest(self):
+        """普通图片上传失败时：抛 SyncError、不上传 manifest、状态为 error"""
+        self.fake_backend.meme_ok = False
+        with self.assertRaises(SyncError) as ctx:
+            sync.push()
+        self.assertIn("上传失败", str(ctx.exception))
+        self.assertFalse(
+            any(p.endswith(INDEX_FILENAME) for p in self.fake_backend.upload_paths)
+        )
+        self.assertEqual(get_sync_progress()["status"], "error")
+
+    def test_manifest_upload_failure_raises(self):
+        """图片上传成功但 manifest 上传失败时：抛 SyncError、状态为 error"""
+        self.fake_backend.manifest_ok = False
+        with self.assertRaises(SyncError) as ctx:
+            sync.push()
+        self.assertIn("manifest", str(ctx.exception))
+        self.assertTrue(
+            any(p.endswith(INDEX_FILENAME) for p in self.fake_backend.upload_paths)
+        )
+        self.assertEqual(get_sync_progress()["status"], "error")
+
+    def test_delete_remote_not_called_on_error(self):
+        """delete_remote=True 且图片上传失败时：不删除任何远端文件"""
+        self.fake_backend.meme_ok = False
+        self.fake_backend.remote_memes = {
+            "ghost.png": {
+                "filename": "ghost.png",
+                "sha256": "x",
+                "file_size": 1,
+                "mtime": "",
+            }
+        }
+        self.cfg.set("sync_delete_remote", True)
+        with self.assertRaises(SyncError):
+            sync.push()
+        self.assertEqual(self.fake_backend.delete_calls, [])
+
+    def test_full_success_uploads_manifest(self):
+        """全部上传成功时：正常返回、上传 manifest、状态为 done"""
+        result = sync.push()
+        self.assertEqual(result["uploaded"], 1)
+        self.assertEqual(result["errors"], 0)
+        self.assertTrue(
+            any(p.endswith(INDEX_FILENAME) for p in self.fake_backend.upload_paths)
+        )
+        self.assertEqual(get_sync_progress()["status"], "done")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -59,6 +59,7 @@ class _FakeBackend:
         self.empty_downloads = set()  # 下载后为空的文件
         self.download_paths = []
         self.list_calls = []
+        self.upload_raises = set()  # 上传时抛异常的文件（触发 worker 异常路径）
 
     @property
     def remote_memes(self):
@@ -115,6 +116,9 @@ class _FakeBackend:
     def upload_file(self, local_path, remote_path):
         rp = str(remote_path)
         self.upload_paths.append(rp)
+        fname = self._basename(rp)
+        if fname in self.upload_raises:
+            raise RuntimeError("upload boom")
         if rp.endswith(INDEX_FILENAME):
             if self.manifest_ok:
                 try:
@@ -552,6 +556,61 @@ class TestSyncPush(unittest.TestCase):
             p for p in self.data_dir.iterdir() if p.name.startswith(".remote-index-")
         ]
         self.assertEqual(leftovers, [])
+
+    # ─── PR6 新增用例 ───
+
+    def test_concurrent_push_rejected(self):
+        """运行锁被占用时第二次 push 抛"同步正在进行中" """
+        from src.sync import _sync_run_lock
+
+        self.assertTrue(_sync_run_lock.acquire(blocking=False))
+        try:
+            with self.assertRaises(SyncError) as ctx:
+                sync.push()
+            self.assertIn("同步正在进行中", str(ctx.exception))
+        finally:
+            _sync_run_lock.release()
+
+    def test_concurrent_pull_rejected(self):
+        """运行锁被占用时 pull 抛"同步正在进行中" """
+        from src.sync import _sync_run_lock
+
+        self.assertTrue(_sync_run_lock.acquire(blocking=False))
+        try:
+            with self.assertRaises(SyncError) as ctx:
+                sync.pull()
+            self.assertIn("同步正在进行中", str(ctx.exception))
+        finally:
+            _sync_run_lock.release()
+
+    def test_push_worker_stats_no_overcount(self):
+        """worker 异常路径：errors 不重复计数（2 个文件各计 1 次）"""
+        self._set_local_memes(
+            [
+                {"filename": "a.png", "sha256": "a"},
+                {"filename": "b.png", "sha256": "b"},
+            ]
+        )
+        self.fake_backend.meme_ok = False  # 上传失败
+        self.fake_backend.upload_raises.add("b.png")  # b.png 上传时抛异常
+        with self.assertRaises(SyncError) as ctx:
+            sync.push()
+        # 旧实现会把 b.png 抛异常的剩余条目重复计数成 3
+        self.assertIn("2 个文件上传失败", str(ctx.exception))
+
+    def test_push_get_backend_failure_releases_lock(self):
+        """_get_backend 抛异常后运行锁被释放，后续 push 可正常执行"""
+        from src.sync import _sync_run_lock
+
+        with patch(
+            "src.sync._get_backend", side_effect=SyncError("No sync type configured")
+        ):
+            with self.assertRaises(SyncError):
+                sync.push()
+        self.assertFalse(_sync_run_lock.locked())
+        # 锁已释放，可再次正常 push
+        result = sync.push()
+        self.assertEqual(result["uploaded"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_webdav_backend.py
+++ b/tests/test_webdav_backend.py
@@ -1,0 +1,316 @@
+"""WebDAV 后端单元测试 — mock urllib.request，不访问网络"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import urllib.error
+
+from src import sync
+from src.sync import SyncError, _WebDAVBackend
+
+
+class _FakeResp:
+    """模拟 HTTP 响应：支持 with、可读一次正文"""
+
+    def __init__(self, status=207, body=b""):
+        self.status = status
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self, *a, **k):
+        data, self.body = self.body, b""
+        return data
+
+
+def _make_backend(url="https://dav.example.com", user="u", password="p", path=""):
+    cfg = {
+        "webdav_url": url,
+        "webdav_user": user,
+        "webdav_password": password,
+        "webdav_path": path,
+    }
+    bk = _WebDAVBackend(cfg)
+    bk.connect()
+    return bk
+
+
+class TestWebDAVURL(unittest.TestCase):
+    def test_url_quotes_path_segments(self):
+        bk = _make_backend()
+        self.assertEqual(
+            bk._url("memes/a b.png"), "https://dav.example.com/memes/a%20b.png"
+        )
+        self.assertEqual(
+            bk._url("memes/表情.png"),
+            "https://dav.example.com/memes/%E8%A1%A8%E6%83%85.png",
+        )
+        self.assertEqual(
+            bk._url("memes/a#b.png"), "https://dav.example.com/memes/a%23b.png"
+        )
+        self.assertEqual(
+            bk._url("memes/a?b.png"), "https://dav.example.com/memes/a%3Fb.png"
+        )
+        self.assertEqual(bk._url(""), "https://dav.example.com")
+
+    def test_connect_normalizes_base_url_path(self):
+        bk = _make_backend(url="https://host/dav/my folder")
+        self.assertEqual(bk.base_url, "https://host/dav/my%20folder")
+        self.assertEqual(
+            bk._url("memes/a.png"), "https://host/dav/my%20folder/memes/a.png"
+        )
+
+    def test_connect_no_double_encode(self):
+        bk = _make_backend(url="https://host/dav/%E8%A1%A8%E6%83%85")
+        self.assertEqual(bk.base_url, "https://host/dav/%E8%A1%A8%E6%83%85")
+
+    def test_connect_rejects_bad_scheme(self):
+        with self.assertRaises(SyncError):
+            _make_backend(url="not-a-url")
+
+    def test_connect_rejects_missing_host(self):
+        with self.assertRaises(SyncError):
+            _make_backend(url="http:///dav")
+
+    def test_connect_non_numeric_timeout_defaults(self):
+        cfg = {
+            "webdav_url": "https://host",
+            "webdav_user": "u",
+            "webdav_password": "p",
+            "webdav_path": "",
+            "webdav_timeout": "abc",
+        }
+        bk = _WebDAVBackend(cfg)
+        bk.connect()
+        self.assertEqual(bk.timeout, 30)
+
+
+class TestWebDAVFileExists(unittest.TestCase):
+    def setUp(self):
+        self.bk = _make_backend()
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_404_returns_false(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError("u", 404, "nf", {}, None)
+        self.assertFalse(self.bk.file_exists("memes/a.png"))
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_207_returns_true(self, urlopen):
+        urlopen.return_value = _FakeResp(207)
+        self.assertTrue(self.bk.file_exists("memes/a.png"))
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_401_raises(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError("u", 401, "auth", {}, None)
+        with self.assertRaises(SyncError):
+            self.bk.file_exists("memes/a.png")
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_500_raises(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError("u", 500, "boom", {}, None)
+        with self.assertRaises(SyncError):
+            self.bk.file_exists("memes/a.png")
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_timeout_raises(self, urlopen):
+        urlopen.side_effect = urllib.error.URLError("timed out")
+        with self.assertRaises(SyncError):
+            self.bk.file_exists("memes/a.png")
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_405_falls_back_to_head(self, urlopen):
+        def fake_open(req, timeout=30):
+            if req.method == "PROPFIND":
+                raise urllib.error.HTTPError("u", 405, "method", {}, None)
+            return _FakeResp(200)
+
+        urlopen.side_effect = fake_open
+        self.assertTrue(self.bk.file_exists("memes/a.png"))
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_405_head_404_returns_false(self, urlopen):
+        def fake_open(req, timeout=30):
+            if req.method == "PROPFIND":
+                raise urllib.error.HTTPError("u", 405, "method", {}, None)
+            raise urllib.error.HTTPError("u", 404, "nf", {}, None)
+
+        urlopen.side_effect = fake_open
+        self.assertFalse(self.bk.file_exists("memes/a.png"))
+
+
+class TestWebDAVUpload(unittest.TestCase):
+    def setUp(self):
+        self.bk = _make_backend()
+        fd, name = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        with Path(name).open("wb") as f:
+            f.write(b"fake image")
+        self.local = Path(name)
+
+    def tearDown(self):
+        self.local.unlink(missing_ok=True)
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_3xx_returns_false(self, urlopen):
+        for code in (301, 302, 303):
+            urlopen.side_effect = urllib.error.HTTPError(
+                "u", code, "redirect", {}, None
+            )
+            self.assertFalse(self.bk.upload_file(self.local, "memes/a.png"))
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_sets_content_type(self, urlopen):
+        seen = {}
+
+        def fake_open(req, timeout=30):
+            seen["req"] = req
+            return _FakeResp(201)
+
+        urlopen.side_effect = fake_open
+        self.assertTrue(self.bk.upload_file(self.local, "memes/a.png"))
+        # Request.add_header 内部 capitalize：Content-Type -> Content-type
+        self.assertEqual(
+            seen["req"].get_header("Content-type"), "application/octet-stream"
+        )
+
+
+class TestWebDAVDownload(unittest.TestCase):
+    def setUp(self):
+        self.bk = _make_backend()
+        self.tmp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_download_streams_and_replaces(self, urlopen):
+        urlopen.return_value = _FakeResp(200, b"0123456789")
+        target = self.tmp_dir / "a.png"
+        self.assertTrue(self.bk.download_file("memes/a.png", target))
+        self.assertEqual(target.read_bytes(), b"0123456789")
+        self.assertFalse(Path(str(target) + ".tmp").exists())
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_download_failure_cleans_tmp(self, urlopen):
+        urlopen.side_effect = urllib.error.URLError("boom")
+        target = self.tmp_dir / "a.png"
+        self.assertFalse(self.bk.download_file("memes/a.png", target))
+        self.assertFalse(Path(str(target) + ".tmp").exists())
+        self.assertFalse(target.exists())
+
+
+class TestWebDAVTestConnection(unittest.TestCase):
+    @patch("src.sync.urllib.request.urlopen")
+    def test_ok_on_207(self, urlopen):
+        urlopen.return_value = _FakeResp(207)
+        bk = _make_backend(path="memes")
+        bk.test_connection()
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_401_raises(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError("u", 401, "auth", {}, None)
+        bk = _make_backend(path="memes")
+        with self.assertRaises(SyncError):
+            bk.test_connection()
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_404_raises(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError("u", 404, "nf", {}, None)
+        bk = _make_backend(path="memes")
+        with self.assertRaises(SyncError) as ctx:
+            bk.test_connection()
+        self.assertIn("首次上传将自动创建", str(ctx.exception))
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_timeout_raises(self, urlopen):
+        urlopen.side_effect = urllib.error.URLError("timed out")
+        bk = _make_backend(path="memes")
+        with self.assertRaises(SyncError):
+            bk.test_connection()
+
+
+class TestSyncTestWebDAV(unittest.TestCase):
+    @patch("src.sync._get_backend")
+    def test_sync_test_probes_connection(self, get_backend):
+        class _Bk:
+            def connect(self):
+                pass
+
+            def close(self):
+                pass
+
+            def test_connection(self):
+                raise SyncError("boom")
+
+        get_backend.return_value = _Bk()
+        self.assertEqual(sync.sync_test(), "boom")
+
+
+class TestWebDAVList(unittest.TestCase):
+    @patch("src.sync.urllib.request.urlopen")
+    def test_unquotes_href(self, urlopen):
+        body = (
+            b'<?xml version="1.0"?><D:multistatus xmlns:D="DAV:">'
+            b"<D:response><D:href>/dav/memes/a%20b.png</D:href></D:response>"
+            b"<D:response><D:href>/dav/memes/%E8%A1%A8%E6%83%85.png</D:href></D:response>"
+            b"</D:multistatus>"
+        )
+        urlopen.return_value = _FakeResp(207, body)
+        bk = _make_backend(url="https://host/dav")
+        self.assertEqual(bk.list_files("memes"), ["a b.png", "表情.png"])
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_invalid_xml_raises(self, urlopen):
+        urlopen.return_value = _FakeResp(207, b"<not-xml")
+        bk = _make_backend(url="https://host/dav")
+        with self.assertRaises(SyncError):
+            bk.list_files("memes")
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_405_raises(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError("u", 405, "method", {}, None)
+        bk = _make_backend(url="https://host/dav")
+        with self.assertRaises(SyncError):
+            bk.list_files("memes")
+
+
+class TestWebDAVEnsureDir(unittest.TestCase):
+    @patch("src.sync.urllib.request.urlopen")
+    def test_405_ok(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError("u", 405, "exists", {}, None)
+        bk = _make_backend()
+        self.assertTrue(bk.ensure_remote_dir("memes"))
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_301_existing_collection_ok(self, urlopen):
+        # MKCOL 301，PROPFIND 复核确认集合存在 → 幂等继续
+        urlopen.side_effect = [
+            urllib.error.HTTPError("u", 301, "moved", {}, None),
+            _FakeResp(207),
+        ]
+        bk = _make_backend()
+        self.assertTrue(bk.ensure_remote_dir("memes"))
+
+    @patch("src.sync.urllib.request.urlopen")
+    def test_301_missing_collection_raises(self, urlopen):
+        # MKCOL 301，PROPFIND 复核确认集合不存在 → 判失败
+        urlopen.side_effect = [
+            urllib.error.HTTPError("u", 301, "moved", {}, None),
+            urllib.error.HTTPError("u", 404, "nf", {}, None),
+        ]
+        bk = _make_backend()
+        with self.assertRaises(SyncError):
+            bk.ensure_remote_dir("memes")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概述

WebDAV 同步链路的健壮性加固。重点解决同步中断导致的数据不一致、上传/下载失败无感知、多端并发互相踩踏、云端残留孤儿文件等问题，并补齐 WebDAV 后端的超时与路径转义处理。

## 变更内容

### 修复

- **上传失败处理** — push/pull 失败不再静默吞掉，失败项进入 `failed_items` 列表
- **manifest 与真实文件一致性** — `_push_worker` / `_pull_worker` 重构，缩略图独立管理，修复清单记录与实际云端文件对不上的问题
- **远端校验** — 拉取前对远端文件有效性做校验
- **中断清理** — 新增 `cleanup_stale_temp_files()`，启动时自动清理中断遗留的 `.remote-*` / `*.tmp` 临时文件（`src/main.py`）
- **manifest 原子写入** — 清单改为 `tmp` + `os.replace` 原子替换，避免中断留下半写清单

### 新增

- **远端孤儿 GC 与恢复** — `list_remote_orphans()` / `cleanup_remote_orphans(delete)`，扫描云端没有对应清单项的孤儿文件，设置页可一键物理删除
- **互斥锁** — 同步过程加锁，防止推 / 拉并发执行互相踩踏
- **UI 失败项显示** — 同步失败后前端展示失败文件列表，便于定位
- **WebDAV 后端加固** — 新增 `test_connection` / `list_files` / `_quote_path`（路径转义）；新增 `webdav_timeout` 配置（默认 30s）

### 测试

- `tests/test_sync.py`（+673 行）— 覆盖失败项、互斥、孤儿 GC、中断清理等
- `tests/test_webdav_backend.py`（+316 行，新增）— WebDAV 后端连接 / 列表 / 路径转义
- `tests/test_core.py`、`tests/test_startup.py` — 适配性调整

## 涉及文件

| 文件 | 改动 |
|---|---|
| `src/sync.py` | +746 / −188，核心逻辑 |
| `src/webui.py` | 失败项返回、`get_remote_orphans` API |
| `src/webui/settings.html` | 孤儿清理入口、失败项展示 |
| `src/main.py` | 启动时清理临时文件 |
| `src/config.py` | 新增 `webdav_timeout` |
| `src/manifest.py` | 原子写入 |
| `tests/*` | 测试 +989 行 |

## 测试

本地已跑通 `pytest`（若你还没跑，建议 PR 前确认一次全绿）。

## Summary by Sourcery

加强基于 WebDAV 的同步机制，使其在面对故障和中断时更加健壮、可观测且一致。

New Features:
- 通过后端辅助函数和 WebUI 控件暴露远程孤立文件（orphan）检测及可选删除能力。
- 添加显式的 WebDAV 连接测试、目录列出和路径引用（path-quoting）工具，以及可配置的请求超时时间。
- 将逐文件的同步失败信息暴露到 UI，让用户可以看到哪些文件失败以及失败原因。

Bug Fixes:
- 通过跟踪失败的条目并在任意文件传输失败时中止 manifest 更新，避免静默的上传/下载失败。
- 确保远程与本地 manifest 保持一致，包括首次同步场景、manifest 损坏以及部分失败的情况。
- 修复远程删除处理逻辑，将不存在的文件视为已删除，并将不确定的删除操作报告出来而不是静默丢弃。
- 通过验证下载结果并在数据库写入失败时进行清理，避免产生零字节或孤立的缓存文件。
- 在启动时清理过期的临时同步文件，避免中断运行留下残留。
- 使用 `tmp + os.replace` 模式使 manifest 写入具备原子性，防止中断时出现半写入文件。
- 规范化 WebDAV URL，支持不提供 PROPFIND 的服务器，并改进针对认证、网络和能力问题的错误报告。
- 防止并发的 push/pull 运行相互重叠而破坏同步状态。

Enhancements:
- 优化 push/pull worker 逻辑，以验证远程文件存在性、在需要时重新上传，并保持统计与失败报告的准确性。
- 在 `delete_remote` 被禁用时，将仍然存在的“仅远程”文件合并进 manifest，避免云端出现孤立对象。
- 改进 `delete_remote` 语义，引入删除后的验证以及明确的未知/错误状态跟踪。
- 扩展同步进度状态，携带结构化的 `failed_items`，供后端和 UI 使用。
- 调整测试和启动代码，以获得更简洁的断言和导入顺序，并在 `AGENTS.md` 中记录更新后的同步路径。

Documentation:
- 更新代理（agent）文档，以反映缩略图同步的移除以及当前的远程路径布局。

Tests:
- 添加针对 manifest 一致性、故障处理、孤立文件清理、临时文件清理、锁定机制和进度报告的全面同步回归测试。
- 添加专门的 WebDAV 后端测试套件，通过 HTTP mock 覆盖 URL 处理、文件存在性检测、上传/下载、PROPFIND/HEAD 回退、列出功能以及目录创建的边界情况。
- 更新核心与启动测试以反映 API 变更并提升可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden WebDAV-based sync to be more robust, observable, and consistent in the face of failures and interruptions.

New Features:
- Expose remote orphan detection and optional deletion via backend helpers and a WebUI control.
- Add explicit WebDAV connection testing, directory listing, and path-quoting utilities, plus configurable request timeout.
- Surface per-file sync failures to the UI so users can see which files failed and why.

Bug Fixes:
- Prevent silent upload/download failures by tracking failed items and aborting manifest updates when any file transfer fails.
- Ensure remote and local manifests stay consistent, including first-sync cases, corrupted manifests, and partial failures.
- Fix remote deletion handling so nonexistent files are treated as deleted and uncertain deletes are reported instead of silently dropped.
- Avoid zero-byte or orphaned cache files by validating downloads and cleaning up on DB write failures.
- Clean up stale temporary sync files on startup to avoid residue from interrupted runs.
- Make manifest writes atomic using a tmp+os.replace pattern to avoid half-written files on interruption.
- Normalize WebDAV URLs, handle PROPFIND-less servers, and improve error reporting for auth, network, and capability issues.
- Prevent concurrent push/pull runs from overlapping and corrupting sync state.

Enhancements:
- Refine push/pull worker logic to verify remote file existence, re-upload when needed, and keep stats and failure reporting accurate.
- Merge surviving remote-only files into the manifest when delete_remote is disabled, avoiding cloud-side orphan objects.
- Improve delete_remote semantics with post-delete verification and clear unknown/error status tracking.
- Extend sync progress state to carry structured failed_items for backend and UI consumption.
- Adjust tests and startup code for cleaner assertions and import ordering, and document the updated sync paths in AGENTS.md.

Documentation:
- Update agent documentation to reflect the removal of thumbnail sync and the current remote path layout.

Tests:
- Add extensive sync regression tests around manifest consistency, failure handling, orphan cleanup, temp-file cleanup, locking, and progress reporting.
- Add a dedicated WebDAV backend test suite that mocks HTTP to cover URL handling, file existence, uploads/downloads, PROPFIND/HEAD fallbacks, listing, and directory creation edge cases.
- Update core and startup tests to reflect API changes and improve reliability.

</details>