### PR TITLE
fix:  Ctrl 异常与旧库 stego_of_hash 启动崩溃

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -89,7 +89,6 @@ class MemeDB:
 
             CREATE INDEX IF NOT EXISTS idx_memes_hash ON memes(file_hash);
             CREATE INDEX IF NOT EXISTS idx_memes_name ON memes(filename);
-            CREATE INDEX IF NOT EXISTS idx_memes_stego ON memes(stego_of_hash);
             CREATE INDEX IF NOT EXISTS idx_recent_uses_at ON recent_uses(used_at);
         """)
         # 迁移旧表：添加可能缺失的列
@@ -110,6 +109,11 @@ class MemeDB:
                 conn.execute(f"ALTER TABLE {tbl} ADD COLUMN {col} {col_def}")
             except sqlite3.OperationalError:
                 pass  # 列已存在
+        # 该索引依赖迁移新增的 stego_of_hash 列，必须放在迁移之后建，
+        # 否则旧库缺列时 CREATE INDEX 会抛 OperationalError 中断启动
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memes_stego ON memes(stego_of_hash)"
+        )
         conn.commit()
 
     def close(self):

--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -41,7 +41,8 @@ class GlobalHotkey:
         try:
             import keyboard
 
-            keyboard.add_hotkey(hotkey, callback, suppress=True)
+            # suppress=True 会安装 WH_KEYBOARD_LL 状态机，吞掉按键事件
+            keyboard.add_hotkey(hotkey, callback, suppress=False)
             self._backend = "keyboard"
             self._active = True
             logger.info(f"全局快捷键已注册 (keyboard): {hotkey}")


### PR DESCRIPTION
### 修复内容

**1. 全局热键吞掉 Ctrl 首按 (src/hotkey.py)**
- 原因: `keyboard.add_hotkey(..., suppress=True)` 安装 WH_KEYBOARD_LL 状态机，吞掉热键修饰键（Ctrl/Alt）的首次按下，导致系统 `GetKeyState(Ctrl)` 延迟约 1s 生效，其他应用 Ctrl+滚轮 需长按约 1s 才识别。
- 修复: 改为 `suppress=False`，非阻塞路径回调同样触发，系统级 Ctrl 键状态即时生效。

**2. 旧库启动崩溃 (src/database.py)**
- 原因: `CREATE INDEX idx_memes_stego ON memes(stego_of_hash)` 在 `executescript` 中先于 `ALTER TABLE` 迁移执行，旧库缺 `stego_of_hash` 列时启动即抛 `OperationalError`，迁移代码根本走不到。
- 修复: 索引移至迁移之后、`conn.commit()` 之前创建。

### 验证
- `ruff check src/ tests/` 通过
- 全量测试 25 passed（含此前失败的 `test_webui_import`）
- 旧 schema 库模拟迁移：`stego_of_hash`/`from_stego` 列 + 索引均补齐，无异常

### 测试
- [x] 本地测试通过

## Summary by Sourcery

修复全局快捷键处理，并使数据库迁移与现有模式兼容。

Bug Fixes:
- 防止在注册全局快捷键时吞掉第一次按下的 Ctrl，从而使系统和其他应用程序能够立即识别 Ctrl 状态。
- 避免在现有数据库缺少 `stego_of_hash` 列时启动崩溃，方法是在迁移添加该列之后才创建依赖该列的索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix global hotkey handling and make database migration compatible with existing schemas.

Bug Fixes:
- Prevent the first Ctrl press from being swallowed when registering global hotkeys, so system and other applications immediately recognize Ctrl state.
- Avoid startup crashes on existing databases missing the stego_of_hash column by creating the dependent index only after migration adds the column.

</details>