### PR TITLE
feat: push 动态维护远端 manifest，孤儿删除加进度条与互斥锁

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ tests/
 - `_push_worker`/`_pull_worker`: 接收文件子列表，操作独立后端连接，原子递增 `_sync_state`
 - `_sync_lock` (`threading.Lock`) 保护 `_sync_state` 写操作；`_increment_sync_progress()` 提供原子递增
 - `_chunk_list(lst, n)` 将文件列表均匀切分给各线程
+- **push 动态 manifest 维护**: `push()` 上传过程中每 `_HEARTBEAT_INTERVAL`（5s）用「远端已有 + 本次已确认上传」快照增量更新远端 manifest（`_build_push_manifest` + `_upload_manifest_data`，失败仅告警不中断）；部分失败中断前也上传该快照（避免远端有文件却无有效 manifest）；成功路径在合并远端独有项后补入已上传但不在本地清单的项（去重 guard），保本地被清空等边角。manifest 只列确认上传成功的文件，不产生幻影条目
 
 ### 更新
 - GitHub API 查询: `/releases/latest` → `/releases?per_page=5` 回退

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ tests/
 - `_chunk_list(lst, n)` 将文件列表均匀切分给各线程
 - **push 动态 manifest 维护**: `push()` 上传过程中每 `_HEARTBEAT_INTERVAL`（5s）用「远端已有 + 本次已确认上传」快照增量更新远端 manifest（`_build_push_manifest` + `_upload_manifest_data`，失败仅告警不中断）；部分失败中断前也上传该快照（避免远端有文件却无有效 manifest）；成功路径在合并远端独有项后补入已上传但不在本地清单的项（去重 guard），保本地被清空等边角。manifest 只列确认上传成功的文件，不产生幻影条目
 - **孤儿清理互斥与进度**: `cleanup_remote_orphans(delete=True)` 删除前非阻塞获取 `_sync_run_lock`（被 push/pull 占用时返回「同步正在进行中」，绝不并发删除）；删除循环复用 `_sync_state`（`direction="delete"`，更新 current_file/files_done/files_total/progress，状态 deleting→done），前端复用 `#sync-progress-overlay` 轮询展示；扫描（delete=False）不互斥
+- **远端文件名校验**: `_safe_remote_fname()` 拒绝路径穿越/绝对路径/隐藏名；`_fetch_remote_memes` 解析远端 manifest 时过滤不安全文件名（含非 dict 条目），`_pull_worker` 下载前二次校验
 
 ### 更新
 - GitHub API 查询: `/releases/latest` → `/releases?per_page=5` 回退

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ tests/
 - `_sync_lock` (`threading.Lock`) 保护 `_sync_state` 写操作；`_increment_sync_progress()` 提供原子递增
 - `_chunk_list(lst, n)` 将文件列表均匀切分给各线程
 - **push 动态 manifest 维护**: `push()` 上传过程中每 `_HEARTBEAT_INTERVAL`（5s）用「远端已有 + 本次已确认上传」快照增量更新远端 manifest（`_build_push_manifest` + `_upload_manifest_data`，失败仅告警不中断）；部分失败中断前也上传该快照（避免远端有文件却无有效 manifest）；成功路径在合并远端独有项后补入已上传但不在本地清单的项（去重 guard），保本地被清空等边角。manifest 只列确认上传成功的文件，不产生幻影条目
+- **孤儿清理互斥与进度**: `cleanup_remote_orphans(delete=True)` 删除前非阻塞获取 `_sync_run_lock`（被 push/pull 占用时返回「同步正在进行中」，绝不并发删除）；删除循环复用 `_sync_state`（`direction="delete"`，更新 current_file/files_done/files_total/progress，状态 deleting→done），前端复用 `#sync-progress-overlay` 轮询展示；扫描（delete=False）不互斥
 
 ### 更新
 - GitHub API 查询: `/releases/latest` → `/releases?per_page=5` 回退

--- a/src/sync.py
+++ b/src/sync.py
@@ -1456,7 +1456,12 @@ def list_remote_orphans(bk, remote_root) -> list:
 
 
 def cleanup_remote_orphans(delete: bool = False) -> dict:
-    """识别远端孤儿文件；delete=True 时物理删除，返回 {ok, orphans, removed}。"""
+    """识别远端孤儿文件；delete=True 时物理删除，返回 {ok, orphans, removed}。
+
+    删除与 push/pull 互斥（_sync_run_lock），并通过 _sync_state 上报进度供前端轮询。
+    """
+    if delete and not _sync_run_lock.acquire(blocking=False):
+        return {"ok": False, "error": "同步正在进行中"}
     cfg = get_config()
     remote_root = _remote_root(cfg)
     bk = _get_backend()
@@ -1465,15 +1470,32 @@ def cleanup_remote_orphans(delete: bool = False) -> dict:
         orphans = list_remote_orphans(bk, remote_root)
         removed = 0
         if delete:
-            for fname in orphans:
-                rem_path = remote_root.rstrip("/") + "/" + REMOTE_MEME_DIR + "/" + fname
-                if bk.delete_file(rem_path):
-                    removed += 1
+            total = len(orphans)
+            if total:
+                _reset_sync_state("delete", total, 0)
+                _update_sync_state(status="deleting", start_time=time.time())
+                for i, fname in enumerate(orphans, 1):
+                    _update_sync_state(
+                        current_file=fname, files_done=i - 1, files_total=total
+                    )
+                    rem_path = (
+                        remote_root.rstrip("/") + "/" + REMOTE_MEME_DIR + "/" + fname
+                    )
+                    if bk.delete_file(rem_path):
+                        removed += 1
+                    _update_sync_state(progress=int(i * 100 / total))
+                _update_sync_state(
+                    status="done", progress=100, files_done=total, current_file=""
+                )
         return {"ok": True, "orphans": orphans, "removed": removed}
     except Exception as e:
         logger.warning("cleanup_remote_orphans failed: %s", e)
+        if delete:
+            _update_sync_state(status="error", error=str(e))
         return {"ok": False, "error": str(e)}
     finally:
+        if delete:
+            _sync_run_lock.release()
         bk.close()
 
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -9,7 +9,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 from ftplib import FTP, error_perm
 from pathlib import Path
 from typing import Optional
@@ -98,6 +98,7 @@ def get_sync_progress() -> dict:
 
 REMOTE_INDEX = INDEX_FILENAME
 REMOTE_MEME_DIR = "memes"
+_HEARTBEAT_INTERVAL = 5  # push 上传过程中 manifest 增量更新的心跳间隔（秒）
 
 
 class SyncError(Exception):
@@ -737,11 +738,11 @@ def _safe_remote_fname(name: str) -> bool:
 
 
 def _fetch_remote_memes(bk, remote_root):
-    """下载远端 manifest 并返回 {filename: entry} 字典（无 manifest 返回 {}）"""
+    """下载远端 manifest，返回 (memes, collections)；无 manifest 返回 ({}, [])"""
     cfg = get_config()
     remote_path = remote_root.rstrip("/") + "/" + REMOTE_INDEX
     if not bk.file_exists(remote_path):
-        return {}
+        return {}, []
     fd, tmp_name = tempfile.mkstemp(
         prefix=".remote-index-", suffix=".json", dir=str(cfg.data_dir)
     )
@@ -752,11 +753,12 @@ def _fetch_remote_memes(bk, remote_root):
             raise SyncError("远端 manifest 下载失败")
         raw_bytes = tmp.read_bytes()
         rdata = json.loads(raw_bytes.decode("utf-8"))
-        return {
+        memes = {
             m["filename"]: m
             for m in rdata.get("memes", [])
-            if _safe_remote_fname(m.get("filename", ""))
+            if isinstance(m, dict) and _safe_remote_fname(m.get("filename", ""))
         }
+        return memes, rdata.get("collections", [])
     except SyncError:
         raise
     except Exception as e:
@@ -766,11 +768,44 @@ def _fetch_remote_memes(bk, remote_root):
             tmp.unlink()
 
 
+def _build_push_manifest(remote_memes, remote_collections, local_idx, uploaded):
+    """构建当前远端应呈现的 manifest 数据（远端已有 + 本次成功上传）"""
+    merged = dict(remote_memes)
+    for fname in uploaded:
+        entry = local_idx.get(fname)
+        if entry:
+            merged[fname] = entry
+    return {
+        "version": 3,
+        "memes": list(merged.values()),
+        "collections": remote_collections,
+    }
+
+
+def _upload_manifest_data(bk, remote_root, data):
+    """把 manifest 数据写入远端（临时文件，上传后清理），返回 bool"""
+    cfg = get_config()
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".remote-merged-", suffix=".json", dir=str(cfg.data_dir)
+    )
+    os.close(fd)
+    tmp = Path(tmp_name)
+    try:
+        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        return bk.upload_file(tmp, remote_root.rstrip("/") + "/" + REMOTE_INDEX)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except Exception:
+                pass
+
+
 # ─── 多线程工作函数 ───
 
 
-def _push_worker(entries, remote_root, cache_dir, remote_memes):
-    """单线程批量上传一批文件"""
+def _push_worker(entries, remote_root, cache_dir, remote_memes, uploaded):
+    """单线程批量上传一批文件；uploaded 记录成功上传条目（受 _sync_lock 保护）"""
     bk = _get_backend()
     bk.connect()
     local_results = {"uploaded": 0, "skipped": 0, "errors": 0, "bytes": 0, "failed": []}
@@ -802,6 +837,8 @@ def _push_worker(entries, remote_root, cache_dir, remote_memes):
             if bk.upload_file(local_file, rem_path):
                 local_results["uploaded"] += 1
                 local_results["bytes"] += fsize
+                with _sync_lock:
+                    uploaded[fname] = entry
                 _increment_sync_progress(files_add=1, bytes_add=fsize)
             else:
                 local_results["errors"] += 1
@@ -1049,7 +1086,7 @@ def push(delete_remote: bool = None) -> dict:
         bk = _get_backend()
         bk.connect()
         bk.ensure_remote_dir(remote_root)
-        remote_memes = _fetch_remote_memes(bk, remote_root)
+        remote_memes, remote_collections = _fetch_remote_memes(bk, remote_root)
         local_idx = {m["filename"]: m for m in local["memes"]}
 
         entries = local["memes"]
@@ -1065,22 +1102,64 @@ def push(delete_remote: bool = None) -> dict:
             "bytes": 0,
             "failed": [],
         }
+        uploaded = {}
         with ThreadPoolExecutor(max_workers=len(chunks)) as executor:
             futures = [
-                executor.submit(_push_worker, ch, remote_root, cache_dir, remote_memes)
+                executor.submit(
+                    _push_worker, ch, remote_root, cache_dir, remote_memes, uploaded
+                )
                 for ch in chunks
             ]
-            for future in as_completed(futures):
-                r = future.result()
-                aggregated["uploaded"] += r["uploaded"]
-                aggregated["skipped"] += r["skipped"]
-                aggregated["errors"] += r["errors"]
-                aggregated["bytes"] += r["bytes"]
-                aggregated["failed"].extend(r.get("failed", []))
+            # 心跳：上传过程中周期性增量更新远端 manifest，中断/崩溃后远端仍可下载
+            last_hb = time.time()
+            pending = set(futures)
+            while pending:
+                done, pending = wait(pending, timeout=_HEARTBEAT_INTERVAL)
+                for future in done:
+                    r = future.result()
+                    aggregated["uploaded"] += r["uploaded"]
+                    aggregated["skipped"] += r["skipped"]
+                    aggregated["errors"] += r["errors"]
+                    aggregated["bytes"] += r["bytes"]
+                    aggregated["failed"].extend(r.get("failed", []))
+                if time.time() - last_hb >= _HEARTBEAT_INTERVAL:
+                    last_hb = time.time()
+                    with _sync_lock:
+                        snap = dict(uploaded)
+                    if snap:
+                        hb_data = _build_push_manifest(
+                            remote_memes, remote_collections, local_idx, snap
+                        )
+                        try:
+                            if not _upload_manifest_data(bk, remote_root, hb_data):
+                                logger.warning("sync heartbeat manifest upload failed")
+                        except Exception as e:
+                            logger.warning(
+                                "sync heartbeat manifest upload error: %s", e
+                            )
 
         if aggregated["errors"] > 0:
+            with _sync_lock:
+                snap = dict(uploaded)
+            manifest_note = "未更新远端 manifest"
+            if snap:
+                # 中断前把已上传文件写进远端 manifest，保证远端仍可下载
+                abort_data = _build_push_manifest(
+                    remote_memes, remote_collections, local_idx, snap
+                )
+                try:
+                    if _upload_manifest_data(bk, remote_root, abort_data):
+                        manifest_note = "远端 manifest 已更新为已上传项"
+                    else:
+                        logger.warning(
+                            "sync push aborted: remote manifest update failed"
+                        )
+                except Exception as e:
+                    logger.warning(
+                        "sync push aborted: remote manifest update error: %s", e
+                    )
             _update_sync_state(failed_items=aggregated["failed"])
-            msg = "%d 个文件上传失败，未更新远端 manifest" % aggregated["errors"]
+            msg = "%d 个文件上传失败，%s" % (aggregated["errors"], manifest_note)
             logger.warning("sync push aborted: %s", msg)
             raise SyncError(msg)
 
@@ -1140,9 +1219,17 @@ def push(delete_remote: bool = None) -> dict:
                 for fname, m in remote_memes.items()
                 if fname not in local_fnames and fname not in deleted_fnames
             ]
+            # 补：已上传但不在本地清单的项（如上传过程中本地被清空）
+            with _sync_lock:
+                snap = dict(uploaded)
+            in_manifest = set(local_fnames) | {m["filename"] for m in kept}
+            fallback = [
+                local_idx[f] for f in snap if f not in in_manifest and f in local_idx
+            ]
             manifest_file = cfg.data_dir / INDEX_FILENAME
-            if kept:
+            if kept or fallback:
                 data["memes"].extend(kept)
+                data["memes"].extend(fallback)
                 fd, tmp_name = tempfile.mkstemp(
                     prefix=".remote-merged-", suffix=".json", dir=str(cfg.data_dir)
                 )
@@ -1326,7 +1413,7 @@ def delete_all_remote() -> dict:
     bk = _get_backend()
     bk.connect()
     try:
-        remote_memes = _fetch_remote_memes(bk, remote_root)
+        remote_memes, _ = _fetch_remote_memes(bk, remote_root)
         count = 0
         for fname in remote_memes:
             rem_path = remote_root.rstrip("/") + "/" + REMOTE_MEME_DIR + "/" + fname
@@ -1361,7 +1448,7 @@ def list_remote_orphans(bk, remote_root) -> list:
         logger.warning("list_files %s failed: %s", remote_path, e)
         return []
     try:
-        remote_memes = _fetch_remote_memes(bk, remote_root)
+        remote_memes, _ = _fetch_remote_memes(bk, remote_root)
     except Exception as e:
         logger.warning("list_remote_orphans fetch manifest failed: %s", e)
         return []

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -380,30 +380,65 @@ let _orphanFiles = [];
 async function scanOrphans() {
   const status = document.getElementById('s-orphan-status');
   const del = document.getElementById('btn-orphan-delete');
+  const scan = document.getElementById('btn-orphan-scan');
+  scan.disabled = true;
+  del.disabled = true;
   status.textContent = '扫描中...';
-  const r = await api('get_remote_orphans', false);
-  if (!r || !r.ok) {
-    status.textContent = '扫描失败: ' + ((r && r.error) || '未知错误');
-    return;
+  try {
+    const r = await api('get_remote_orphans', false);
+    if (!r || !r.ok) {
+      status.textContent = '扫描失败: ' + ((r && r.error) || '未知错误');
+      return;
+    }
+    _orphanFiles = r.orphans || [];
+    status.textContent = _orphanFiles.length
+      ? '发现 ' + _orphanFiles.length + ' 个孤儿文件'
+      : '无孤儿文件';
+    del.disabled = _orphanFiles.length === 0;
+  } finally {
+    scan.disabled = false;
   }
-  _orphanFiles = r.orphans || [];
-  status.textContent = _orphanFiles.length
-    ? '发现 ' + _orphanFiles.length + ' 个孤儿文件'
-    : '无孤儿文件';
-  del.disabled = _orphanFiles.length === 0;
 }
 
 async function deleteOrphans() {
   if (!_orphanFiles.length) return;
   const status = document.getElementById('s-orphan-status');
+  const del = document.getElementById('btn-orphan-delete');
+  const scan = document.getElementById('btn-orphan-scan');
+  // 前置灰两个孤儿按钮，避免删除期间并发扫描/重复删除
+  del.disabled = true;
+  scan.disabled = true;
+  status.textContent = '删除中...';
+  // 复用同步进度条 overlay（隐藏“后台运行”按钮）
+  const bgBtn = document.getElementById('sync-progress-bg-btn');
+  document.getElementById('sync-progress-title').textContent = '删除孤儿文件...';
+  document.getElementById('sync-progress-file').textContent = '准备中...';
+  document.getElementById('sync-progress-bar').style.width = '0%';
+  document.getElementById('sync-progress-pct').textContent = '0%';
+  document.getElementById('sync-progress-speed').textContent = '';
+  bgBtn.style.display = 'none';
+  document.getElementById('sync-progress-overlay').style.display = 'flex';
+
+  const pollTimer = setInterval(async () => {
+    const s = await api('get_sync_progress');
+    if (!s || s.status === 'idle') return;
+    document.getElementById('sync-progress-file').textContent = s.current_file || '';
+    document.getElementById('sync-progress-bar').style.width = (s.progress || 0) + '%';
+    document.getElementById('sync-progress-pct').textContent = (s.progress || 0) + '%';
+  }, 300);
+
   const r = await api('get_remote_orphans', true);
+  clearInterval(pollTimer);
+  document.getElementById('sync-progress-overlay').style.display = 'none';
+  bgBtn.style.display = '';
+  scan.disabled = false;
   if (!r || !r.ok) {
     status.textContent = '删除失败: ' + ((r && r.error) || '未知错误');
     return;
   }
-  status.textContent = '已删除 ' + r.removed + ' 个孤儿文件';
   _orphanFiles = [];
-  document.getElementById('btn-orphan-delete').disabled = true;
+  del.disabled = true;
+  status.textContent = '已删除 ' + r.removed + ' 个孤儿文件';
 }
 
 async function showUploadWarning() {

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -521,6 +521,60 @@ class TestSyncPush(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["orphans"], [])
 
+    def test_cleanup_orphans_delete_reports_progress(self):
+        """删除孤儿：向 _sync_state 上报进度（direction/files_total/files_done/progress）"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        self.fake_backend.remote_files.add("o1.png")
+        self.fake_backend.remote_files.add("o2.png")
+        result = cleanup_remote_orphans(delete=True)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["removed"], 2)
+        s = get_sync_progress()
+        self.assertEqual(s["direction"], "delete")
+        self.assertEqual(s["status"], "done")
+        self.assertEqual(s["files_total"], 2)
+        self.assertEqual(s["files_done"], 2)
+        self.assertEqual(s["progress"], 100)
+
+    def test_cleanup_orphans_delete_respects_run_lock(self):
+        """删除孤儿：push/pull 进行中（_sync_run_lock 被持）→ 拒并发，不删任何文件"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        self.fake_backend.remote_files.add("o1.png")
+        self.assertTrue(sync._sync_run_lock.acquire(blocking=False))
+        try:
+            result = cleanup_remote_orphans(delete=True)
+        finally:
+            sync._sync_run_lock.release()
+        self.assertFalse(result["ok"])
+        self.assertIn("同步正在进行中", result["error"])
+        self.assertIn("o1.png", self.fake_backend.remote_files)  # 未删除
+
+    def test_cleanup_orphans_delete_releases_run_lock(self):
+        """删除孤儿：完成后释放 _sync_run_lock，后续删除/同步可正常执行"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        self.fake_backend.remote_files.add("o1.png")
+        result1 = cleanup_remote_orphans(delete=True)
+        self.assertTrue(result1["ok"])
+        # 锁已释放：可再次获取，且再次删除仍成功
+        self.assertTrue(sync._sync_run_lock.acquire(blocking=False))
+        sync._sync_run_lock.release()
+        self.fake_backend.remote_files.add("o2.png")
+        result2 = cleanup_remote_orphans(delete=True)
+        self.assertTrue(result2["ok"])
+        self.assertEqual(result2["removed"], 1)
+
+    def test_cleanup_orphans_scan_ignores_run_lock(self):
+        """扫描孤儿（delete=False）：不与 push/pull 互斥，持锁时仍可扫描"""
+        self.fake_backend.remote_memes = {"a.png": _entry("a.png", "x")}
+        self.fake_backend.remote_files.add("o1.png")
+        self.assertTrue(sync._sync_run_lock.acquire(blocking=False))
+        try:
+            result = cleanup_remote_orphans(delete=False)
+        finally:
+            sync._sync_run_lock.release()
+        self.assertTrue(result["ok"])
+        self.assertIn("o1.png", result["orphans"])
+
     # ─── PR5 新增用例 ───
 
     def test_cleanup_stale_temp_files(self):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -848,6 +848,28 @@ class TestSyncPush(unittest.TestCase):
         self.assertEqual(memes, {})
         self.assertEqual(collections, [])
 
+    def test_fetch_remote_memes_filters_unsafe_filenames(self):
+        """远端 manifest 中的不安全文件名（路径穿越/绝对路径/隐藏/非 dict）被过滤"""
+        self.fake_backend.manifest_content = json.dumps(
+            {
+                "version": 3,
+                "memes": [
+                    {"filename": "safe.png", "sha256": "x"},
+                    {"filename": "../evil.png", "sha256": "x"},
+                    {"filename": "/abs.png", "sha256": "x"},
+                    {"filename": ".hidden.png", "sha256": "x"},
+                    {"filename": "a/b.png", "sha256": "x"},
+                    {"filename": "..\\win.png", "sha256": "x"},
+                    {"filename": "~user.png", "sha256": "x"},
+                    {"filename": ".", "sha256": "x"},
+                    {"filename": "..", "sha256": "x"},
+                    "not-a-dict",
+                ],
+            }
+        )
+        memes, _ = _fetch_remote_memes(self.fake_backend, "/")
+        self.assertEqual(set(memes.keys()), {"safe.png"})
+
 
 class TestSafeRemoteFname(unittest.TestCase):
     """远端 manifest 文件名安全校验（防路径穿越）"""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,7 +1,8 @@
 """sync.push() 远端 manifest 一致性回归测试
 
 覆盖 push() 的修复：
-- 任一普通图片上传失败 → 抛 SyncError，且不上传新的远端 manifest
+- 任一普通图片上传失败 → 抛 SyncError；若已有文件成功上传，中断前仍上传反映远端真实状态的 manifest（成功项 + 远端已有项）
+- 上传过程中心跳式增量更新远端 manifest（崩溃/被杀后远端仍可下载）
 - manifest 上传失败 → 抛 SyncError
 - 上传失败不删除远端文件
 - delete_remote=False 时远端仍保留的文件合并进远端 manifest（避免孤儿）
@@ -15,6 +16,7 @@ import json
 import shutil
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -25,7 +27,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from src import sync
 from src.config import Config
 from src.manifest import INDEX_FILENAME
-from src.sync import SyncError, cleanup_remote_orphans, get_sync_progress
+from src.sync import SyncError, _fetch_remote_memes, cleanup_remote_orphans, get_sync_progress
 
 
 def _entry(fname, sha256, size=1):
@@ -667,6 +669,130 @@ class TestSyncPush(unittest.TestCase):
         self.assertEqual(len(failed), 1)
         self.assertEqual(failed[0]["filename"], "missing.png")
         self.assertEqual(failed[0]["status"], "error")
+
+    # ─── PR9 新增用例：push 动态 manifest 维护 ───
+
+    def _manifest_upload_count(self):
+        return sum(
+            1 for p in self.fake_backend.upload_paths if p.endswith(INDEX_FILENAME)
+        )
+
+    def test_push_partial_failure_uploads_manifest_on_abort(self):
+        """部分上传失败 → 抛 SyncError，但中断前上传含成功项（不含失败项）的 manifest"""
+        self._set_local_memes(
+            [
+                {"filename": "a.png", "sha256": "a"},
+                {"filename": "b.png", "sha256": "b"},
+            ]
+        )
+        self.fake_backend.upload_raises.add("b.png")
+        with self.assertRaises(SyncError) as ctx:
+            sync.push()
+        self.assertIn("远端 manifest 已更新", str(ctx.exception))
+        self.assertGreaterEqual(self._manifest_upload_count(), 1)
+        payload = self.fake_backend.manifest_payload
+        self.assertEqual(
+            {m["filename"] for m in payload["memes"]}, {"a.png"}
+        )
+
+    def test_push_abort_after_mid_push_local_delete(self):
+        """上传中途本地被清空（模拟 delete_all_local）→ abort 后 manifest 仍含已上传文件"""
+        self._set_local_memes(
+            [
+                {"filename": "a.png", "sha256": "a"},
+                {"filename": "b.png", "sha256": "b"},
+            ]
+        )
+        real_upload = self.fake_backend.upload_file
+
+        def deleting_upload(local_path, remote_path):
+            rp = str(remote_path)
+            ok = real_upload(local_path, remote_path)
+            if ok and not rp.endswith(INDEX_FILENAME):
+                # 模拟 delete_all_local：删除剩余文件的 cache 并清空 DB
+                (self.data_dir / "cache" / "b.png").unlink(missing_ok=True)
+                self.fake_db.rows = []
+            return ok
+
+        self.fake_backend.upload_file = deleting_upload
+        with self.assertRaises(SyncError):
+            sync.push()
+        self.assertGreaterEqual(self._manifest_upload_count(), 1)
+        payload = self.fake_backend.manifest_payload
+        self.assertEqual(
+            {m["filename"] for m in payload["memes"]}, {"a.png"}
+        )
+
+    def test_heartbeat_updates_manifest_during_upload(self):
+        """上传过程中心跳增量更新 manifest（≥2 次上传，最终 payload 完整）"""
+        self._set_local_memes(
+            [
+                {"filename": "a.png", "sha256": "a"},
+                {"filename": "b.png", "sha256": "b"},
+                {"filename": "c.png", "sha256": "c"},
+                {"filename": "d.png", "sha256": "d"},
+            ]
+        )
+        real_upload = self.fake_backend.upload_file
+
+        def slow_upload(local_path, remote_path):
+            if not str(remote_path).endswith(INDEX_FILENAME):
+                time.sleep(0.05)
+            return real_upload(local_path, remote_path)
+
+        self.fake_backend.upload_file = slow_upload
+        with patch("src.sync._HEARTBEAT_INTERVAL", 0.01):
+            result = sync.push()
+        self.assertEqual(result["uploaded"], 4)
+        self.assertGreaterEqual(self._manifest_upload_count(), 2)
+        payload = self.fake_backend.manifest_payload
+        self.assertEqual(
+            {m["filename"] for m in payload["memes"]},
+            {"a.png", "b.png", "c.png", "d.png"},
+        )
+
+    def test_success_fallback_keeps_uploaded_after_late_delete(self):
+        """上传全部成功但本地 DB 被清空（删除发生在最终 manifest 前）→ 最终 manifest 仍含已上传文件"""
+        self._set_local_memes(
+            [
+                {"filename": "a.png", "sha256": "a"},
+                {"filename": "b.png", "sha256": "b"},
+            ]
+        )
+        real_upload = self.fake_backend.upload_file
+
+        def clearing_upload(local_path, remote_path):
+            rp = str(remote_path)
+            ok = real_upload(local_path, remote_path)
+            if ok and not rp.endswith(INDEX_FILENAME):
+                self.fake_db.rows = []  # 模拟 build_manifest 前 DB 已被清空
+            return ok
+
+        self.fake_backend.upload_file = clearing_upload
+        result = sync.push()
+        self.assertEqual(result["errors"], 0)
+        payload = self.fake_backend.manifest_payload
+        self.assertEqual(
+            {m["filename"] for m in payload["memes"]},
+            {"a.png", "b.png"},
+        )
+
+    def test_fetch_remote_memes_returns_collections(self):
+        """_fetch_remote_memes 返回 (memes, collections)，无 manifest 时返回 ({}, [])"""
+        self.fake_backend.manifest_content = json.dumps(
+            {
+                "version": 3,
+                "memes": [{"filename": "a.png", "sha256": "x"}],
+                "collections": [{"name": "grp", "filenames": ["a.png"]}],
+            }
+        )
+        memes, collections = _fetch_remote_memes(self.fake_backend, "/")
+        self.assertEqual(set(memes.keys()), {"a.png"})
+        self.assertEqual(collections, [{"name": "grp", "filenames": ["a.png"]}])
+        self.fake_backend.manifest_exists = False
+        memes, collections = _fetch_remote_memes(self.fake_backend, "/")
+        self.assertEqual(memes, {})
+        self.assertEqual(collections, [])
 
 
 class TestSafeRemoteFname(unittest.TestCase):


### PR DESCRIPTION
## 背景

两个相关联的同步稳定性问题：

1. **push 中断丢失 manifest**：`push()` 只在全部上传成功时一次性写入远端 manifest，上传过程中若用户操作导致部分失败（如清空本地、断开连接），远端已上传的文件没有任何有效 manifest 引用，`pull()` 报「no remote manifest available」无法下载。
2. **孤儿删除无反馈、无互斥**：`cleanup_remote_orphans(delete=True)` 是同步串行删除循环，不写 `_sync_state`、不取 `_sync_run_lock`——大量孤儿时 UI 无任何进度反馈，表现为「应用卡死」；且可与 push/pull 真并发，存在删除正在上传/清单更新中文件的竞态。

## 改动内容

### 1. push 动态维护远端 manifest（`139463d`）
- **心跳增量更新**：上传过程中每 `_HEARTBEAT_INTERVAL`（5s）用「远端已有 + 本次已确认上传」快照增量更新远端 manifest（`_build_push_manifest` + `_upload_manifest_data`，失败仅告警不中断）。
- **中断兜底**：部分失败中断前也上传该快照，避免远端有文件却无有效 manifest。
- **成功路径 fallback + 去重 guard**：合并远端独有项后补入已上传但不在本地清单的项，覆盖「上传完成后、最终 manifest 上传前本地被清空」等边角。
- manifest 只列**确认上传成功**的文件，不产生幻影条目，保持 PR #22 的全有或全无设计动机。

### 2. 孤儿删除进度条 + 互斥锁（`47285e6`）
- **互斥**：`cleanup_remote_orphans(delete=True)` 删除前非阻塞获取 `_sync_run_lock`，push/pull 进行中返回「同步正在进行中」，绝不并发删除。
- **进度上报**：删除循环复用 `_sync_state`（`direction="delete"`，更新 current_file/files_done/files_total/progress，状态 `deleting → done`），设置页复用现有 `#sync-progress-overlay` 300ms 轮询展示，删除不再「看起来卡死」。
- **前端置灰**：`deleteOrphans`/`scanOrphans` 在 await 前置灰按钮，防止删除期间并发扫描/重复删除。

## 测试

- `tests/test_sync.py` 新增 **9** 个用例：动态 manifest 5 个（部分失败中断上传、上传中清空本地、心跳多次更新、晚删除 fallback、`_fetch_remote_memes` 返回 collections）+ 孤儿清理 4 个（进度上报、持锁拒删、锁释放、扫描不互斥）。
- `python -m pytest tests/test_sync.py tests/test_webdav_backend.py` → **71 passed**。
- `ruff check src/` + `black --check src/` → 通过。
- 已本地编译 exe（`scripts/build.py --build-only`）验证打包正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

在推送过程中动态维护远程清单（remote manifest），并添加互斥的、带进度汇报的孤立文件（orphan）清理机制，同时更新相应的测试、UI 和文档说明。

Bug 修复：
- 确保在推送操作部分完成或中断时，远程清单依然保持一致，并准确反映已成功上传的文件。

增强功能：
- 通过心跳快照在推送期间周期性更新远程清单，并在本地索引在同步中途被清空时，添加保留已上传文件的回退机制。
- 扩展远程清单的获取逻辑，使其在返回 memes 的同时也返回 collections，并将该能力传播到删除和孤立文件列举操作中。
- 通过共享锁使孤立文件删除与 push/pull 互斥，并通过现有的同步状态机制报告删除进度。

文档：
- 在 AGENTS.md 中记录推送过程中动态维护清单的行为，以及孤立文件清理的加锁与进度汇报行为。

测试：
- 增加回归测试，用于覆盖在部分失败、推送过程中本地删除、心跳更新、成功回退以及 collection 处理场景下的动态清单更新。
- 增加测试，用于覆盖孤立文件删除进度汇报、锁处理以及扫描操作非互斥行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Dynamically maintain the remote manifest during push and add mutually-exclusive, progress-reporting orphan cleanup, with corresponding tests, UI updates, and documentation notes.

Bug Fixes:
- Ensure partial or interrupted push operations still leave a consistent remote manifest that reflects successfully uploaded files.

Enhancements:
- Periodically update the remote manifest during push via heartbeat snapshots and add a fallback to retain uploaded files when the local index is cleared mid-sync.
- Extend remote manifest fetching to return collections alongside memes and propagate this to delete and orphan listing operations.
- Make orphan deletion mutually exclusive with push/pull via a shared lock and report deletion progress through the existing sync state mechanism.

Documentation:
- Document dynamic push manifest maintenance and orphan cleanup locking/progress behavior in AGENTS.md.

Tests:
- Add regression tests for dynamic manifest updates on partial failures, mid-push local deletions, heartbeat updates, success fallbacks, and collection handling.
- Add tests covering orphan deletion progress reporting, lock handling, and non-mutual exclusion for scan operations.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **同步改进**
  - 同步过程中可持续更新远端清单，异常中断时尽量保留已成功上传的文件。
  - 支持同时处理远端文件与集合数据，并过滤不安全文件名。
  - 增强孤儿文件清理的互斥控制、进度反馈和错误状态提示。

- **界面改进**
  - 扫描或删除期间自动禁用相关操作，避免重复执行。
  - 新增删除进度覆盖层和状态轮询，完成后自动恢复界面状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->