### PR TITLE
fix(webui): 强制静态资源 MIME，规避注册表 .js 被改写导致加载动画卡死 (#34)

### DIFF
--- a/src/webui.py
+++ b/src/webui.py
@@ -105,6 +105,18 @@ install_log_buffer()
 
 HTML_DIR = Path(__file__).resolve().parent / "webui"
 
+# 静态资源扩展名 → 强制 Content-Type：本机 mimetypes/注册表 .js 映射可能为
+# text/plain，叠加 nosniff 会被 Chromium 拒执行脚本
+_STATIC_MIME_TYPES = {
+    ".js": "text/javascript",
+    ".css": "text/css",
+    ".html": "text/html",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".ico": "image/x-icon",
+    ".woff2": "font/woff2",
+}
+
 # ─── 工具函数  ───
 
 
@@ -2394,18 +2406,12 @@ class WebUI:
 
         @app.route("/<filepath:path>")
         def static_files(filepath):
-            # 按扩展名强制 MIME：本机 mimetypes/注册表 .js 映射可能为 text/plain，
-            # 叠加 nosniff 会被 Chromium 拒执行脚本（表现为加载动画永转）
-            ctype = {
-                ".js": "text/javascript",
-                ".css": "text/css",
-                ".html": "text/html",
-                ".svg": "image/svg+xml",
-                ".png": "image/png",
-                ".ico": "image/x-icon",
-                ".woff2": "font/woff2",
-            }.get(os.path.splitext(filepath)[1].lower())
-            return bottle.static_file(filepath, root=str(HTML_DIR), mimetype=ctype)
+            # 按扩展名强制 MIME，规避本机 .js 映射被改写成 text/plain 时
+            # 叠加 nosniff 导致 Chromium 拒执行脚本；未知类型走 bottle 自动检测
+            ctype = _STATIC_MIME_TYPES.get(os.path.splitext(filepath)[1].lower())
+            if ctype:
+                return bottle.static_file(filepath, root=str(HTML_DIR), mimetype=ctype)
+            return bottle.static_file(filepath, root=str(HTML_DIR))
 
         bottle.run(app, host="127.0.0.1", port=self._port, quiet=True)
 

--- a/src/webui.py
+++ b/src/webui.py
@@ -2394,7 +2394,18 @@ class WebUI:
 
         @app.route("/<filepath:path>")
         def static_files(filepath):
-            return bottle.static_file(filepath, root=str(HTML_DIR))
+            # 按扩展名强制 MIME：本机 mimetypes/注册表 .js 映射可能为 text/plain，
+            # 叠加 nosniff 会被 Chromium 拒执行脚本（表现为加载动画永转）
+            ctype = {
+                ".js": "text/javascript",
+                ".css": "text/css",
+                ".html": "text/html",
+                ".svg": "image/svg+xml",
+                ".png": "image/png",
+                ".ico": "image/x-icon",
+                ".woff2": "font/woff2",
+            }.get(os.path.splitext(filepath)[1].lower())
+            return bottle.static_file(filepath, root=str(HTML_DIR), mimetype=ctype)
 
         bottle.run(app, host="127.0.0.1", port=self._port, quiet=True)
 


### PR DESCRIPTION
0.5.0 起前端 JS 外置为 /index.js 并加 nosniff 安全头；
故障机 Windows 注册表 .js MIME 映射为 text/plain，Bottle 经
mimetypes.guess_type 返回 text/plain，Chromium 拒执行脚本， 整个前端逻辑未运行，加载动画永转。0.4.1 内联 JS 免疫。

static_files 路由按扩展名强制正确 Content-Type（.js/.css/.html 等）， 绕过本机 mimetypes/注册表。用 bottle 0.13.4 复现验证：修复前
text/plain（被拦），修复后 text/javascript/text/css（通过）。

## Summary by Sourcery

Bug Fixes:
- 确保 JavaScript、CSS、HTML 以及其他静态资源在被提供时使用明确的 `Content-Type` 头部，而不依赖主机的 MIME 类型/注册表配置，防止由于脚本被当作纯文本处理而导致 Web UI 卡在加载动画界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure JavaScript, CSS, HTML and other static resources are served with explicit Content-Type headers independent of host mimetypes/registry configuration, preventing the web UI from hanging on the loading animation due to scripts being treated as plain text.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化静态文件的 MIME 类型识别，确保 JavaScript、CSS、HTML、SVG、PNG、ICO 和 WOFF2 等资源以正确格式提供。
  * 改善网页资源加载兼容性，减少因类型识别不准确导致的显示或加载问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->