### PR TITLE
fix(lan): 虚拟网卡环境 UDP 发现回包走错接口，安卓端收不到 hello

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ tests/
 
 ### 局域网互联 (lan.py)
 - **入口**: `lan.start(port, secret)` / `lan.stop()`，`get_status()` 供设置页轮询；`set_allow_secret_config()` 控制是否允许密钥传输（仅内存生效），`set_confirm_callback()` 注入设备确认回调（WebUI 提供）
-- **UDP 发现**: 绑定 `0.0.0.0:port`，收到 `{"t":"discover"}` → 单播回 `{"t":"hello","name","os","ver","need_secret"}`（**不含任何密钥信息**）
+- **UDP 发现**: 绑定 `0.0.0.0:port`，收到 `{"t":"discover"}` → 单播回 `{"t":"hello","name","os","ver","need_secret"}`（**不含任何密钥信息**）；启用 `IP_PKTINFO`（Linux/Windows）后用 `recvmsg` 取广播到达接口（Linux `ipi_spec_dst` 得接口 IP、Windows 8 字节 `in_pktinfo` 只有接口索引无 spec_dst），`sendmsg` 把回包源地址钉在该接口（Windows 用 `IP_UNICAST_IF`+`connect`+`getsockname` 由索引反查接口 IP，发送时 `ipi_addr` 字段填源地址），虚拟网卡/多网卡环境回包不会走错接口或带上虚拟适配器 IP；`recvmsg` 不可用或非 Linux/Windows 退化 `recvfrom`/`sendto`
 - **TCP 握手（明文帧）**: `[4B 长度][JSON]`；服务端发 `challenge{nonce}` → 客户端回 `proof{HMAC-SHA256(secret, nonce)}` → 验 `ok`/`no`（3 次错误断开）；无密钥时直接放行
 - **数据帧（加密）**: `[4B 长度][12B IV][AES-GCM 密文+16B tag]`；密钥由 PBKDF2(secret, 100000) 派生；JSON 载荷，命令由手机（客户端）发起
 - **设备确认（连接前置）**: 客户端握手后发 `device_info` 帧（`{name,model,os,ver}`，手机 Build.MODEL/MANUFACTURER/versionName）；桌面端 `_cmd_device_info` 弹窗展示设备信息，用户允许/拒绝后回 `{ok, approved, allow_secret_config}`；**未确认期间其他命令挂起**（`confirmed` Event，等待超时 60s 后拒），无确认回调（测试/无 UI）默认放行；`confirm_device()` 由 JS 回传批准结果（`pending_confirm` 记录 + `threading.Event`）；WebUI 主窗口 `showLanDeviceConfirm()` 弹窗 → `JsApi.lan_confirm_device` 回传

--- a/src/lan.py
+++ b/src/lan.py
@@ -93,9 +93,7 @@ class LanServer:
             self._udp_sock.settimeout(0.5)
             self._udp_pktinfo = False
             try:
-                self._udp_sock.setsockopt(
-                    socket.IPPROTO_IP, socket.IP_PKTINFO, 1
-                )
+                self._udp_sock.setsockopt(socket.IPPROTO_IP, socket.IP_PKTINFO, 1)
                 self._udp_pktinfo = True
             except (AttributeError, OSError):
                 pass
@@ -241,7 +239,9 @@ class LanServer:
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             try:
-                s.setsockopt(socket.IPPROTO_IP, 31, struct.pack("I", ifindex))
+                opt = getattr(socket, "IP_UNICAST_IF", 31)
+                # IP_UNICAST_IF 接口索引须为网络字节序（MSDN），勿用本机字节序
+                s.setsockopt(socket.IPPROTO_IP, opt, struct.pack("!I", ifindex))
                 s.connect((peer[0], peer[1]))
                 return s.getsockname()[0]
             finally:

--- a/src/lan.py
+++ b/src/lan.py
@@ -10,6 +10,7 @@ import os
 import platform
 import socket
 import struct
+import sys
 import threading
 import time
 from pathlib import Path
@@ -68,6 +69,7 @@ class LanServer:
         self._port = 0
         self._secret = ""
         self._clients = {}
+        self._udp_pktinfo = False
 
     # --- 生命周期 ---
 
@@ -89,6 +91,14 @@ class LanServer:
             self._udp_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self._udp_sock.bind(("0.0.0.0", self._port))
             self._udp_sock.settimeout(0.5)
+            self._udp_pktinfo = False
+            try:
+                self._udp_sock.setsockopt(
+                    socket.IPPROTO_IP, socket.IP_PKTINFO, 1
+                )
+                self._udp_pktinfo = True
+            except (AttributeError, OSError):
+                pass
             self._tcp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self._tcp_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self._tcp_sock.bind(("0.0.0.0", self._port))
@@ -148,8 +158,16 @@ class LanServer:
     def _udp_loop(self):
         while self._running:
             try:
-                data, addr = self._udp_sock.recvfrom(2048)
+                if self._udp_pktinfo:
+                    data, ancdata, _, addr = self._udp_sock.recvmsg(2048, 256)
+                else:
+                    data, addr = self._udp_sock.recvfrom(2048)
+                    ancdata = []
             except socket.timeout:
+                continue
+            except (AttributeError, NotImplementedError):
+                # recvmsg 不可用的平台：禁 pktinfo 退化 recvfrom，继续发现
+                self._udp_pktinfo = False
                 continue
             except OSError:
                 break
@@ -166,12 +184,70 @@ class LanServer:
                 "ver": __version__,
                 "need_secret": bool(self._secret),
             }
+            payload = json.dumps(reply, ensure_ascii=False).encode("utf-8")
+            src_addr = self._extract_pktinfo_src(ancdata)
             try:
-                self._udp_sock.sendto(
-                    json.dumps(reply, ensure_ascii=False).encode("utf-8"), addr
-                )
+                self._send_udp_reply(payload, addr, src_addr)
             except OSError:
                 pass
+
+    def _extract_pktinfo_src(self, ancdata):
+        """提取广播到达的本地接口（Linux 返回 ("ip", ip)；Windows ("ifindex", n)）"""
+        for level, ctype, cdata in ancdata:
+            if level != socket.IPPROTO_IP or ctype != socket.IP_PKTINFO:
+                continue
+            try:
+                if sys.platform == "win32":
+                    # Windows in_pktinfo 仅 8 字节 (ipi_addr, ipi_ifindex)，无
+                    # spec_dst；ipi_addr 是目的地址（广播），只有接口索引可用
+                    _, ifindex = struct.unpack("4sI", cdata)
+                    if not ifindex:
+                        return None
+                    return ("ifindex", ifindex)
+                else:
+                    _, spec_dst, _ = struct.unpack("i4s4s", cdata)
+                    return ("ip", socket.inet_ntoa(spec_dst))
+            except (struct.error, OSError):
+                return None
+        return None
+
+    def _send_udp_reply(self, data, addr, src):
+        """UDP 回包：可固定源接口则 sendmsg（多网卡/虚拟网卡环境保证回包走真实网卡）"""
+        if self._udp_pktinfo and src:
+            try:
+                kind, val = src
+                pinfo = None
+                if sys.platform == "win32" and kind == "ifindex":
+                    src_ip = self._win_ifindex_source_ip(val, addr)
+                    if src_ip:
+                        # Windows 发送时 ipi_addr 为源地址，ipi_ifindex 指定出口
+                        pinfo = struct.pack("4sI", socket.inet_aton(src_ip), val)
+                elif kind == "ip":
+                    pinfo = struct.pack("i4s4s", 0, socket.inet_aton(val), b"\x00" * 4)
+                if pinfo:
+                    self._udp_sock.sendmsg(
+                        [data],
+                        [(socket.IPPROTO_IP, socket.IP_PKTINFO, pinfo)],
+                        0,
+                        addr,
+                    )
+                    return
+            except (AttributeError, NotImplementedError, struct.error, OSError):
+                logger.debug("LAN UDP 回包 sendmsg 失败，退化为 sendto")
+        self._udp_sock.sendto(data, addr)
+
+    def _win_ifindex_source_ip(self, ifindex, peer):
+        """Windows：用 IP_UNICAST_IF 钉住接收接口，connect 后 getsockname 取该接口 IP"""
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                s.setsockopt(socket.IPPROTO_IP, 31, struct.pack("I", ifindex))
+                s.connect((peer[0], peer[1]))
+                return s.getsockname()[0]
+            finally:
+                s.close()
+        except OSError:
+            return None
 
     # --- TCP 会话 ---
 

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -149,8 +149,10 @@ def test_udp_discovery(lan_env):
     assert reply["ver"]
 
 
-def test_pktinfo_extract_linux_layout():
+def test_pktinfo_extract_linux_layout(monkeypatch):
     """Linux in_pktinfo 布局 (ifindex, spec_dst, addr) 解析"""
+    monkeypatch.setattr(lan.socket, "IP_PKTINFO", 8, raising=False)
+    monkeypatch.setattr(lan.sys, "platform", "linux")
     srv = lan.LanServer()
     cdata = struct.pack(
         "i4s4s",
@@ -164,6 +166,7 @@ def test_pktinfo_extract_linux_layout():
 
 def test_pktinfo_extract_windows_layout(monkeypatch):
     """Windows in_pktinfo 仅 8 字节 (ipi_addr, ipi_ifindex)，返回接口索引"""
+    monkeypatch.setattr(lan.socket, "IP_PKTINFO", 8, raising=False)
     monkeypatch.setattr(lan.sys, "platform", "win32")
     srv = lan.LanServer()
     cdata = struct.pack("4sI", socket.inet_aton("255.255.255.255"), 7)
@@ -173,6 +176,7 @@ def test_pktinfo_extract_windows_layout(monkeypatch):
 
 def test_pktinfo_extract_windows_zero_ifindex(monkeypatch):
     """Windows 接口索引为 0（不可用）时返回 None"""
+    monkeypatch.setattr(lan.socket, "IP_PKTINFO", 8, raising=False)
     monkeypatch.setattr(lan.sys, "platform", "win32")
     srv = lan.LanServer()
     cdata = struct.pack("4sI", socket.inet_aton("255.255.255.255"), 0)
@@ -193,6 +197,128 @@ def test_udp_reply_pins_source_interface(lan_env):
     cli.close()
     assert json.loads(data.decode("utf-8"))["t"] == "hello"
     assert src[0] == "127.0.0.1"
+
+
+def test_pktinfo_extract_ignores_other_cmsg(monkeypatch):
+    """非 IP_PKTINFO 控制消息被忽略并返回 None"""
+    monkeypatch.setattr(lan.socket, "IP_PKTINFO", 8, raising=False)
+    srv = lan.LanServer()
+    anc = [
+        (socket.SOL_SOCKET, socket.SO_REUSEADDR, b"\x00\x00\x00\x00"),
+        (socket.IPPROTO_TCP, socket.IP_TTL, b"\x00" * 4),
+    ]
+    assert srv._extract_pktinfo_src(anc) is None
+
+
+def test_pktinfo_extract_short_cdata(monkeypatch):
+    """cdata 过短时解析失败返回 None 而非抛异常"""
+    monkeypatch.setattr(lan.socket, "IP_PKTINFO", 8, raising=False)
+    srv = lan.LanServer()
+    anc = [(socket.IPPROTO_IP, 8, b"\x00")]
+    assert srv._extract_pktinfo_src(anc) is None
+
+
+class _FakeUdpSock:
+    """记录 sendmsg/sendto 调用的假 UDP socket"""
+
+    def __init__(self):
+        self.sendmsg_calls = []
+        self.sendto_calls = []
+
+    def sendmsg(self, buffers, ancdata, flags=0, address=None):
+        self.sendmsg_calls.append(
+            {"buffers": buffers, "ancdata": ancdata, "address": address}
+        )
+
+    def sendto(self, data, address=None):
+        self.sendto_calls.append({"data": data, "address": address})
+
+
+def test_send_udp_reply_uses_sendmsg_with_pktinfo(monkeypatch):
+    """Linux 路径 sendmsg 的 ancdata 携带 IP_PKTINFO（源地址 = 接收接口）"""
+    monkeypatch.setattr(lan.socket, "IP_PKTINFO", 8, raising=False)
+    srv = lan.LanServer()
+    sock = _FakeUdpSock()
+    srv._udp_sock = sock
+    srv._udp_pktinfo = True
+    srv._send_udp_reply(b'{"t":"hello"}', ("192.168.0.1", 12345), ("ip", "192.168.1.5"))
+    assert not sock.sendto_calls
+    assert len(sock.sendmsg_calls) == 1
+    call = sock.sendmsg_calls[0]
+    assert call["address"] == ("192.168.0.1", 12345)
+    level, ctype, cdata = call["ancdata"][0]
+    assert level == socket.IPPROTO_IP and ctype == 8
+    _, spec_dst, _ = struct.unpack("i4s4s", cdata)
+    assert socket.inet_ntoa(spec_dst) == "192.168.1.5"
+
+
+def test_send_udp_reply_windows_sendmsg_pins_ifindex(monkeypatch):
+    """Windows 路径 sendmsg 的 ancdata 源地址填 ipi_addr、接口填 ipi_ifindex"""
+    monkeypatch.setattr(lan.socket, "IP_PKTINFO", 8, raising=False)
+    monkeypatch.setattr(lan.sys, "platform", "win32")
+    srv = lan.LanServer()
+    sock = _FakeUdpSock()
+    srv._udp_sock = sock
+    srv._udp_pktinfo = True
+    monkeypatch.setattr(srv, "_win_ifindex_source_ip", lambda ifindex, peer: "10.0.0.5")
+    srv._send_udp_reply(b'{"t":"hello"}', ("192.168.0.1", 12345), ("ifindex", 7))
+    assert not sock.sendto_calls
+    assert len(sock.sendmsg_calls) == 1
+    level, ctype, cdata = sock.sendmsg_calls[0]["ancdata"][0]
+    assert level == socket.IPPROTO_IP and ctype == 8
+    ipi_addr, ipi_ifindex = struct.unpack("4sI", cdata)
+    assert socket.inet_ntoa(ipi_addr) == "10.0.0.5"
+    assert ipi_ifindex == 7
+
+
+def test_win_ifindex_source_ip_sets_unicast_if(monkeypatch):
+    """Windows 反查接口 IP：用 IP_UNICAST_IF（网络字节序）钉接口并 connect"""
+    monkeypatch.setattr(lan.sys, "platform", "win32")
+    captured = {}
+
+    class _FakeProbeSock:
+        def setsockopt(self, level, optname, value):
+            captured["opt"] = (level, optname, value)
+
+        def connect(self, addr):
+            captured["addr"] = addr
+
+        def getsockname(self):
+            return ("10.0.0.5", 0)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(lan.socket, "socket", lambda *a, **k: _FakeProbeSock())
+    srv = lan.LanServer()
+    assert srv._win_ifindex_source_ip(7, ("192.168.0.1", 12345)) == "10.0.0.5"
+    level, optname, value = captured["opt"]
+    assert level == socket.IPPROTO_IP
+    assert optname == getattr(socket, "IP_UNICAST_IF", 31)
+    assert value == struct.pack("!I", 7)
+    assert captured["addr"] == ("192.168.0.1", 12345)
+
+
+def test_win_ifindex_source_ip_oserror(monkeypatch):
+    """Windows 反查失败（OSError）时返回 None"""
+    monkeypatch.setattr(lan.sys, "platform", "win32")
+
+    class _FakeProbeSock:
+        def setsockopt(self, level, optname, value):
+            raise OSError("no such interface")
+
+        def connect(self, addr):
+            pass
+
+        def getsockname(self):
+            return ("10.0.0.5", 0)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(lan.socket, "socket", lambda *a, **k: _FakeProbeSock())
+    srv = lan.LanServer()
+    assert srv._win_ifindex_source_ip(7, ("192.168.0.1", 12345)) is None
 
 
 def test_handshake_success(lan_env):

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -149,6 +149,52 @@ def test_udp_discovery(lan_env):
     assert reply["ver"]
 
 
+def test_pktinfo_extract_linux_layout():
+    """Linux in_pktinfo 布局 (ifindex, spec_dst, addr) 解析"""
+    srv = lan.LanServer()
+    cdata = struct.pack(
+        "i4s4s",
+        1,
+        socket.inet_aton("192.168.1.5"),
+        socket.inet_aton("255.255.255.255"),
+    )
+    anc = [(socket.IPPROTO_IP, getattr(socket, "IP_PKTINFO", 8), cdata)]
+    assert srv._extract_pktinfo_src(anc) == ("ip", "192.168.1.5")
+
+
+def test_pktinfo_extract_windows_layout(monkeypatch):
+    """Windows in_pktinfo 仅 8 字节 (ipi_addr, ipi_ifindex)，返回接口索引"""
+    monkeypatch.setattr(lan.sys, "platform", "win32")
+    srv = lan.LanServer()
+    cdata = struct.pack("4sI", socket.inet_aton("255.255.255.255"), 7)
+    anc = [(socket.IPPROTO_IP, getattr(socket, "IP_PKTINFO", 8), cdata)]
+    assert srv._extract_pktinfo_src(anc) == ("ifindex", 7)
+
+
+def test_pktinfo_extract_windows_zero_ifindex(monkeypatch):
+    """Windows 接口索引为 0（不可用）时返回 None"""
+    monkeypatch.setattr(lan.sys, "platform", "win32")
+    srv = lan.LanServer()
+    cdata = struct.pack("4sI", socket.inet_aton("255.255.255.255"), 0)
+    anc = [(socket.IPPROTO_IP, getattr(socket, "IP_PKTINFO", 8), cdata)]
+    assert srv._extract_pktinfo_src(anc) is None
+
+
+@pytest.mark.skipif(not hasattr(socket, "IP_PKTINFO"), reason="平台不支持 IP_PKTINFO")
+def test_udp_reply_pins_source_interface(lan_env):
+    """回包源 IP 钉在广播到达的接口上（虚拟网卡环境发现可达）"""
+    cfg, db, tmp = lan_env
+    srv = lan._server
+    assert srv is not None and srv._udp_pktinfo
+    cli = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    cli.settimeout(5)
+    cli.sendto(b'{"t":"discover"}', ("127.0.0.1", TEST_PORT))
+    data, src = cli.recvfrom(2048)
+    cli.close()
+    assert json.loads(data.decode("utf-8"))["t"] == "hello"
+    assert src[0] == "127.0.0.1"
+
+
 def test_handshake_success(lan_env):
     sock = _connect()
     key = _handshake(sock, "test-secret")


### PR DESCRIPTION
### 问题描述

在多网卡 / 虚拟网卡环境（VPN、WSL vEthernet、Hyper-V、VMware 等）下，手机版 OhMyMeme 扫描不到电脑，局域网互联无法配对。

**根因**：`lan.py` 的 UDP 发现 socket 绑定 `0.0.0.0`，收到 `discover` 广播后用**未 connect 的 `sendto`** 单播回包。此时源 IP 与出口网卡由内核路由表决定——存在虚拟网卡时，路由表常把回包导向虚拟适配器或隧道，导致：

- 回包从错误网卡发出，安卓端根本收不到 `hello`
- 或回包源 IP 是虚拟适配器地址（如 `10.x.x.x` / `172.x.x.x`），安卓端无法回连

### 修复方案

启用 `IP_PKTINFO`（Linux / Windows），把回包源地址**钉在广播实际到达的接口**上：

- **Linux**：`recvmsg` 取 `ipi_spec_dst`（接口 IP），`sendmsg` 以 `in_pktinfo`（`ifindex=0, spec_dst=ip`）钉源回包
- **Windows**：`in_pktinfo` 仅 8 字节 `(ipi_addr, ipi_ifindex)`，无 `spec_dst` 字段，且接收时 `ipi_addr` 是目的地址而非接口 IP——因此先取接口索引，再用 `IP_UNICAST_IF` + `connect` + `getsockname` 反查该接口 IP，发送时把源地址填入 `ipi_addr` 字段
- **稳健退化**：`recvmsg` 不可用（非 Linux/Windows 或平台不支持）时禁用 pktinfo 退回 `recvfrom`/`sendto`，不中断发现循环；sendmsg 失败时记录 debug 日志

### 测试

- 新增单测覆盖 Linux / Windows 两种 `in_pktinfo` 布局解析（含接口索引为 0 的边界）
- 新增回包源接口锁定测试（无 `IP_PKTINFO` 平台自动 skip）
- `tests/test_lan.py` 全套 **24 passed**，`ruff check` 通过

> 注：Windows 路径通过 mock `sys.platform` 的单测验证解析逻辑，建议在有虚拟网卡的 Windows 实机确认一次。


Mention to #43 

请在你的虚拟网卡环境下测试一遍

## Summary by Sourcery

确保在多网卡/虚拟网卡环境中，LAN UDP 发现回复使用正确的源网络接口，从而提升 Android 配对的可靠性。

Bug 修复：
- 修复在存在虚拟或多块网络适配器时，UDP 发现回复可能从错误的网络接口或 IP 发出的情况，通过将响应固定到接收数据报的接口上来解决。

增强：
- 在受支持的平台上启用可选的基于 `IP_PKTINFO` 的处理机制，当辅助数据（ancillary data）相关 API 不可用时可优雅回退。
- 新增内部辅助方法，用于解析平台特定的 `in_pktinfo` 结构布局，并在 Linux 和 Windows 上确定 UDP 回复应使用的合适源 IP。

文档：
- 更新 LAN 代理文档，描述基于 `IP_PKTINFO` 的 UDP 发现行为及其回退策略。

测试：
- 新增单元测试，覆盖 Linux 和 Windows 的 `IP_PKTINFO` 辅助数据布局，包括接口索引无效等边界情况。
- 新增类集成测试，确保在 `IP_PKTINFO` 可用时，UDP 发现回复确实从正确的接口发出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure LAN UDP discovery replies use the correct source interface in multi-/virtual-NIC environments to make Android pairing reliable.

Bug Fixes:
- Fix UDP discovery replies being sent from the wrong interface or IP when virtual or multiple network adapters are present by pinning responses to the receiving interface.

Enhancements:
- Enable optional IP_PKTINFO-based handling on supported platforms with graceful fallback when ancillary data APIs are unavailable.
- Add internal helpers to parse platform-specific in_pktinfo layouts and determine the appropriate source IP for UDP replies on Linux and Windows.

Documentation:
- Update LAN agent documentation to describe the IP_PKTINFO-based UDP discovery behavior and its fallback strategy.

Tests:
- Add unit tests covering Linux and Windows IP_PKTINFO ancillary data layouts, including edge cases for invalid interface indices.
- Add an integration-style test ensuring UDP discovery replies originate from the correct interface when IP_PKTINFO is available.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 优化局域网 UDP 设备发现，支持多网卡环境下通过正确的网络接口返回响应。
  * 提升广播发现的可靠性，减少跨网卡通信失败或响应地址不匹配的问题。
  * 在系统不支持相关网络能力时自动降级，确保服务仍可正常运行。

* **测试**
  * 增加 Linux 和 Windows 多网卡接口解析及 UDP 响应来源验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->