### PR TITLE
fix(s3): resolve Alibaba Cloud OSS compatibility (SigV2 + virtual-hosted addressing)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ tests/
 - **push 动态 manifest 维护**: `push()` 上传过程中每 `_HEARTBEAT_INTERVAL`（5s）用「远端已有 + 本次已确认上传」快照增量更新远端 manifest（`_build_push_manifest` + `_upload_manifest_data`，失败仅告警不中断）；部分失败中断前也上传该快照（避免远端有文件却无有效 manifest）；成功路径在合并远端独有项后补入已上传但不在本地清单的项（去重 guard），保本地被清空等边角。manifest 只列确认上传成功的文件，不产生幻影条目
 - **孤儿清理互斥与进度**: `cleanup_remote_orphans(delete=True)` 删除前非阻塞获取 `_sync_run_lock`（被 push/pull 占用时返回「同步正在进行中」，绝不并发删除）；删除循环复用 `_sync_state`（`direction="delete"`，更新 current_file/files_done/files_total/progress，状态 deleting→done），前端复用 `#sync-progress-overlay` 轮询展示；扫描（delete=False）不互斥
 - **远端文件名校验**: `_safe_remote_fname()` 拒绝路径穿越/绝对路径/隐藏名；`_fetch_remote_memes` 解析远端 manifest 时过滤不安全文件名（含非 dict 条目），`_pull_worker` 下载前二次校验
+- **S3 后端 OSS 兼容**: boto3 客户端固定 `signature_version='s3'`（V2 签名，boto3 的 V4 与 chunked encoding 强耦合，OSS 不支持）；寻址方式由 `s3_addressing_style` 配置控制（默认 `"virtual"`，可选 `"path"`），映射到 `BotoConfig(s3={"addressing_style": ...})`；阿里云 OSS 仅支持 virtual-hosted style（bucket 作子域名），path-style 请求被拒绝；设置页 S3 表单「寻址方式」下拉框切换
 
 ### 更新
 - GitHub API 查询: `/releases/latest` → `/releases?per_page=5` 回退

--- a/src/config.py
+++ b/src/config.py
@@ -93,6 +93,7 @@ class Config:
         "s3_bucket": "",
         "s3_access_key": "",
         "s3_secret_key": "",
+        "s3_addressing_style": "virtual",
         # R2
         "r2_account_id": "",
         "r2_access_key_id": "",

--- a/src/config.py
+++ b/src/config.py
@@ -94,6 +94,7 @@ class Config:
         "s3_access_key": "",
         "s3_secret_key": "",
         "s3_addressing_style": "virtual",
+        "s3_signature_version": "s3",
         # R2
         "r2_account_id": "",
         "r2_access_key_id": "",

--- a/src/sync.py
+++ b/src/sync.py
@@ -270,7 +270,11 @@ class _S3Backend(_SyncBackend):
             kwargs["region_name"] = region
 
         try:
-            config = BotoConfig(s3={"payload_signing_enabled": False})
+            addressing = self.cfg.get("s3_addressing_style", "virtual")
+            config = BotoConfig(
+                signature_version="s3",
+                s3={"payload_signing_enabled": False, "addressing_style": addressing},
+            )
             self.client = boto3.client("s3", config=config, **kwargs)
             self.bucket = bucket
             prefix = self.cfg.get("s3_path", "").strip("/")

--- a/src/sync.py
+++ b/src/sync.py
@@ -250,6 +250,7 @@ class _S3Backend(_SyncBackend):
         self.prefix = ""
 
     def connect(self):
+        """连接 S3 后端，创建 boto3 客户端"""
         endpoint = self.cfg.get("s3_endpoint", "")
         region = self.cfg.get("s3_region", "")
         access_key = self.cfg.get("s3_access_key", "")
@@ -271,8 +272,13 @@ class _S3Backend(_SyncBackend):
 
         try:
             addressing = self.cfg.get("s3_addressing_style", "virtual")
+            if addressing not in ("virtual", "path"):
+                addressing = "virtual"
+            sig_ver = self.cfg.get("s3_signature_version", "s3")
+            if sig_ver not in ("s3", "s3v4"):
+                sig_ver = "s3"
             config = BotoConfig(
-                signature_version="s3",
+                signature_version=sig_ver,
                 s3={"payload_signing_enabled": False, "addressing_style": addressing},
             )
             self.client = boto3.client("s3", config=config, **kwargs)

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -270,6 +270,13 @@
           <label>Endpoint URL</label>
           <input id="s3-endpoint" placeholder="https://s3.amazonaws.com">
         </div>
+        <div class="form-group">
+          <label>寻址方式</label>
+          <select id="s3-addressing-style">
+            <option value="virtual">虚拟主机型 (Virtual-hosted)</option>
+            <option value="path">路径型 (Path-style)</option>
+          </select>
+        </div>
         <div class="ftp-row">
           <div class="form-group">
             <label>Region</label>

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -277,6 +277,13 @@
             <option value="path">路径型 (Path-style)</option>
           </select>
         </div>
+        <div class="form-group">
+          <label>签名版本</label>
+          <select id="s3-signature-version">
+            <option value="s3">V2（兼容 OSS）</option>
+            <option value="s3v4">V4（AWS S3）</option>
+          </select>
+        </div>
         <div class="ftp-row">
           <div class="form-group">
             <label>Region</label>

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -219,6 +219,8 @@ async function getSettings() {
   document.getElementById('s3-endpoint').value = s.s3_endpoint || '';
   const s3Addr = document.getElementById('s3-addressing-style');
   if (s3Addr) s3Addr.value = s.s3_addressing_style || 'virtual';
+  const s3Sig = document.getElementById('s3-signature-version');
+  if (s3Sig) s3Sig.value = s.s3_signature_version || 's3';
   document.getElementById('s3-region').value = s.s3_region || '';
   document.getElementById('s3-bucket').value = s.s3_bucket || '';
   document.getElementById('s3-access-key').value = s.s3_access_key || '';
@@ -371,6 +373,7 @@ function collectSyncSettings() {
     s3_secret_key: document.getElementById('s3-secret-key')?.value || '',
     s3_path: document.getElementById('s3-path')?.value || '',
     s3_addressing_style: document.getElementById('s3-addressing-style')?.value || 'virtual',
+    s3_signature_version: document.getElementById('s3-signature-version')?.value || 's3',
     r2_account_id: document.getElementById('r2-account-id')?.value || '',
     r2_access_key_id: document.getElementById('r2-access-key-id')?.value || '',
     r2_secret_access_key: document.getElementById('r2-secret-access-key')?.value || '',

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -217,6 +217,8 @@ async function getSettings() {
   document.getElementById('s-ftp-pass').value = s.ftp_password || '';
   document.getElementById('s-ftp-path').value = s.ftp_path || '/';
   document.getElementById('s3-endpoint').value = s.s3_endpoint || '';
+  const s3Addr = document.getElementById('s3-addressing-style');
+  if (s3Addr) s3Addr.value = s.s3_addressing_style || 'virtual';
   document.getElementById('s3-region').value = s.s3_region || '';
   document.getElementById('s3-bucket').value = s.s3_bucket || '';
   document.getElementById('s3-access-key').value = s.s3_access_key || '';
@@ -368,6 +370,7 @@ function collectSyncSettings() {
     s3_access_key: document.getElementById('s3-access-key')?.value || '',
     s3_secret_key: document.getElementById('s3-secret-key')?.value || '',
     s3_path: document.getElementById('s3-path')?.value || '',
+    s3_addressing_style: document.getElementById('s3-addressing-style')?.value || 'virtual',
     r2_account_id: document.getElementById('r2-account-id')?.value || '',
     r2_access_key_id: document.getElementById('r2-access-key-id')?.value || '',
     r2_secret_access_key: document.getElementById('r2-secret-access-key')?.value || '',


### PR DESCRIPTION
## 问题
用户使用阿里云 OSS 作为 S3 兼容存储后端时，endpoint 能 ping 通但数据传输失败。
## 根因：
1. boto3 默认使用 V4 签名，而 V4 实现与 chunked encoding 强耦合，OSS 不支持 chunked encoding → 签名失败
2. boto3 默认 `addressing_style="auto"`，当 bucket 名不符合 DNS 规范（含下划线等）时退化为 `path-style`，但 OSS 仅支持 `virtual-hosted style `→ 请求被拒绝
## 改动
- config.py: 新增 `s3_addressing_style` 配置项，默认 `"virtual"`
- sync.py: `_S3Backend.connect() `固定 `signature_version='s3'`（V2 签名），按配置映射` addressing_style` 到 `BotoConfig`
- settings.html / settings.js: S3 配置表单加「寻址方式」下拉框（virtual/path），设置页读写新字段
- AGENTS.md: 同步段落补充 S3 OSS 兼容说明
## 影响范围
- S3 同步后端连接逻辑（R2 不受影响）
- 设置页 S3 配置表单新增一个下拉框
## 验证
- 全部 148 个测试通过
- black --check src/ 和 ruff check src/ 通过
- 阿里云官方文档确认：OSS 仅支持 virtual-hosted style，boto3 需使用 V2 签名

## Summary by Sourcery

通过调整客户端配置并在设置中公开寻址风格，提升 S3 后端与阿里云 OSS 的兼容性。

New Features:
- 在同步设置中新增可配置的 S3 寻址风格（virtual 或 path），并将其持久化到配置中。

Bug Fixes:
- 强制 S3 客户端使用 SigV2 签名和显式的寻址风格，以便能够成功连接到阿里云 OSS。

Enhancements:
- 在代理文档中记录 S3 与 OSS 的兼容性细节以及新的寻址风格行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve S3 backend compatibility with Alibaba Cloud OSS by adjusting client configuration and exposing addressing style in settings.

New Features:
- Add configurable S3 addressing style (virtual or path) to sync settings and persist it in configuration.

Bug Fixes:
- Force S3 client to use SigV2 signing and an explicit addressing style to allow successful connections to Alibaba Cloud OSS.

Enhancements:
- Document S3 OSS compatibility details and the new addressing-style behavior in the agent documentation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * S3 同步设置新增寻址方式选项，支持虚拟主机型（Virtual-hosted）和路径型（Path-style）。
  * 新增签名版本选项，支持 V2 和 V4。
  * 默认使用虚拟主机型寻址和 V2 签名，配置保存后将在同步时生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->