### PR TITLE
fix(webui): correct drag sorting across grid layouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ scripts/
 tests/
   test_core.py    # unittest 风格: Version/Config/Crypto/Database
   test_startup.py # pytest 风格: 全生命周期集成测试
+  fixtures/grid_slot_probe.js # Node 网格拖拽槽位回归探针
 ```
 
 ## js_api 桥接规范

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ python -m pytest tests/ -v  # 测试
 
 CI 会自动运行 lint+test。
 
+网格拖拽槽位回归探针位于 `tests/fixtures/grid_slot_probe.js`。
+
 ## 贡献者
 
 [![Contributors](https://contributor.starsfire.top/OhMyMeme/OhMyMeme/)](https://github.com/OhMyMeme/OhMyMeme/graphs/contributors)

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -391,11 +391,15 @@ function gridMetrics() {
   const cards = memeCardsInGrid();
   if (!cards.length) return null;
   const style = getComputedStyle(grid);
-  const paddingLeft = parseFloat(style.paddingLeft) || 0;
-  const paddingRight = parseFloat(style.paddingRight) || 0;
-  const paddingTop = parseFloat(style.paddingTop) || 0;
-  const columnGap = parseFloat(style.columnGap) || 0;
-  const rowGap = parseFloat(style.rowGap) || 0;
+  const finiteStyleValue = (value) => {
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+  const paddingLeft = finiteStyleValue(style.paddingLeft);
+  const paddingRight = finiteStyleValue(style.paddingRight);
+  const paddingTop = finiteStyleValue(style.paddingTop);
+  const columnGap = finiteStyleValue(style.columnGap);
+  const rowGap = finiteStyleValue(style.rowGap);
   const cardWidth = cards[0].offsetWidth;
   const cardHeight = cards[0].offsetHeight;
   const contentWidth = grid.clientWidth - paddingLeft - paddingRight;

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -1,5 +1,5 @@
 let allTags = [], activeTags = new Set(), memes = [], pending = false, copyPending = false;
-let collections = [], activeCollection = -4;
+let collections = [], activeCollection = null;
 let dragSrcId = null;
 const MEME_PAGE = 200;
 let memeOffset = 0, memeHasMore = true, memeLoadingMore = false;
@@ -378,7 +378,7 @@ function canReorderMemes() {
   const q = document.getElementById('search').value.trim();
   if (q || activeTags.size > 0) return false;
   if (!dragSortEnabled) return false;
-  return activeCollection > 0;
+  return activeCollection === null || activeCollection > 0;
 }
 
 function memeCardsInGrid() {

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -390,19 +390,21 @@ function gridMetrics() {
   const gRect = grid.getBoundingClientRect();
   const cards = memeCardsInGrid();
   if (!cards.length) return null;
-  const allCards = Array.from(document.querySelectorAll('#meme-grid .meme-card'));
   const style = getComputedStyle(grid);
-  const gap = parseFloat(style.rowGap) || 10;
-  const first = allCards[0];
+  const paddingLeft = parseFloat(style.paddingLeft) || 0;
+  const paddingRight = parseFloat(style.paddingRight) || 0;
+  const paddingTop = parseFloat(style.paddingTop) || 0;
+  const columnGap = parseFloat(style.columnGap) || 0;
+  const rowGap = parseFloat(style.rowGap) || 0;
   const cardWidth = cards[0].offsetWidth;
   const cardHeight = cards[0].offsetHeight;
-  const contentWidth = grid.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+  const contentWidth = grid.clientWidth - paddingLeft - paddingRight;
   return {
-    originX: gRect.left + first.offsetLeft,
-    originY: gRect.top + first.offsetTop,
-    pitchX: cardWidth + gap,
-    pitchY: cardHeight + gap,
-    cols: Math.max(1, Math.round((contentWidth + gap) / (cardWidth + gap))),
+    originX: gRect.left + grid.clientLeft + paddingLeft,
+    originY: gRect.top + grid.clientTop + paddingTop,
+    pitchX: cardWidth + columnGap,
+    pitchY: cardHeight + rowGap,
+    cols: Math.max(1, Math.round((contentWidth + columnGap) / (cardWidth + columnGap))),
   };
 }
 

--- a/tests/fixtures/grid_slot_probe.js
+++ b/tests/fixtures/grid_slot_probe.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(
+  path.resolve(__dirname, '..', '..', 'src', 'webui', 'index.js'),
+  'utf8'
+);
+const start = source.indexOf('function memeCardsInGrid()');
+const end = source.indexOf('function moveInArray(', start);
+if (start < 0 || end < 0) throw new Error('drag geometry helpers not found');
+
+const folder = { classList: { contains: name => name === 'folder-card' } };
+const meme = () => ({
+  offsetWidth: 100,
+  offsetHeight: 80,
+  classList: { contains: () => false },
+});
+const memes = [meme(), meme(), meme(), meme(), meme()];
+const allCards = [folder, ...memes];
+const layout = { left: 200, top: 100 };
+const style = {
+  paddingLeft: '10px',
+  paddingRight: '10px',
+  paddingTop: '10px',
+  columnGap: '10px',
+  rowGap: '20px',
+};
+const grid = {
+  clientLeft: 0,
+  clientTop: 0,
+  clientWidth: 340,
+  getBoundingClientRect: () => ({ left: layout.left, top: layout.top }),
+};
+folder.offsetLeft = 218;
+folder.offsetTop = 110;
+
+const context = {
+  document: {
+    getElementById: id => {
+      if (id !== 'meme-grid') throw new Error('unexpected element id: ' + id);
+      return grid;
+    },
+    querySelectorAll: selector => selector.includes(':not(.folder-card)') ? memes : allCards,
+  },
+  getComputedStyle: () => style,
+};
+vm.createContext(context);
+vm.runInContext(source.slice(start, end), context);
+
+function assertSlot(label, x, y, expected) {
+  const actual = context.gridSlotIndex(x, y);
+  if (actual !== expected) {
+    throw new Error(label + ': expected meme index ' + expected + ', got ' + actual);
+  }
+}
+
+function assertVisibleSlots(label) {
+  const originX = layout.left + 10;
+  const originY = layout.top + 10;
+  assertSlot(label + ' first meme after folder', originX + 110 + 50, originY + 40, 0);
+  assertSlot(label + ' third meme on next row', originX + 50, originY + 100 + 40, 2);
+}
+
+assertVisibleSlots('expanded sidebar');
+layout.left = 20;
+assertVisibleSlots('collapsed sidebar');
+layout.top = -90;
+assertVisibleSlots('scrolled grid');
+assertSlot('head clamp', -1000, -1000, 0);
+assertSlot('tail clamp', 10000, 10000, 4);
+
+style.paddingLeft = undefined;
+style.paddingRight = 'not-a-number';
+style.paddingTop = 'Infinity';
+style.columnGap = 'Infinity';
+style.rowGap = 'NaN';
+const metrics = context.gridMetrics();
+if (!Object.values(metrics).every(Number.isFinite)) {
+  throw new Error('malformed styles must produce finite grid metrics');
+}
+
+console.log('grid slot behavior: PASS');

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -457,10 +457,13 @@ def test_sorting_visual_feedback_static_contract():
     root = Path(__file__).resolve().parent.parent
     index_js = (root / "src" / "webui" / "index.js").read_text(encoding="utf-8")
     index_css = (root / "src" / "webui" / "index.css").read_text(encoding="utf-8")
+    initial_state = index_js.split("function ", 1)[0]
 
     assert re.search(
-        r"let\s+collections\s*=\s*\[\]\s*,\s*activeCollection\s*=\s*null\s*;",
-        index_js,
+        r"\bcollections\s*=\s*\[\]", initial_state
+    ), "the initial view must initialize without collections"
+    assert re.search(
+        r"\bactiveCollection\s*=\s*null\b", initial_state
     ), "the initial view must remain the all-memes view"
 
     grid_wrap = re.search(r"#grid-wrap\s*\{(?:(?!\}).)*?\}", index_css, re.DOTALL)
@@ -538,28 +541,26 @@ def test_sorting_visual_feedback_static_contract():
     assert can_reorder, "sorting eligibility must remain locally inspectable"
     can_reorder_body = can_reorder.group(0)
     assert re.search(
-        r"if\s*\(\s*q\s*\|\|\s*activeTags\.size\s*>\s*0\s*\)\s*return\s*false",
+        r"if\s*\(\s*q\s*\|\|\s*activeTags\s*\.\s*size\s*>\s*0\s*\)\s*"
+        r"return\s+false\s*;",
         can_reorder_body,
     )
     assert re.search(
-        r"if\s*\(\s*!dragSortEnabled\s*\)\s*return\s*false", can_reorder_body
-    )
-    assert re.search(
-        r"return\s+activeCollection\s*===\s*null\s*\|\|\s*" r"activeCollection\s*>\s*0",
+        r"if\s*\(\s*!\s*dragSortEnabled\s*\)\s*return\s+false\s*;",
         can_reorder_body,
     )
     assert re.search(
-        r"if\s*\(\s*activeCollection\s*>\s*0\s*\)\s*\{\s*"
-        r"ok\s*=\s*await\s+api\(\s*['\"]reorder_collection_members['\"]\s*,\s*"
-        r"activeCollection",
+        r"return\s+activeCollection\s*===\s*null\s*\|\|\s*"
+        r"activeCollection\s*>\s*0\s*;",
+        can_reorder_body,
+    )
+    assert re.search(
+        r"activeCollection\s*>\s*0[\s\S]*?api\(\s*['\"]reorder_collection_members['\"]\s*,\s*activeCollection",
         index_js,
-        re.DOTALL,
     ), "sortable collections must persist their member order through the active collection"
     assert re.search(
-        r"else\s*\{\s*ok\s*=\s*await\s+api\(\s*['\"]reorder_memes['\"]\s*,\s*"
-        r"memes\.map\(\s*x\s*=>\s*x\.id\s*\)",
+        r"api\(\s*['\"]reorder_memes['\"]\s*,\s*memes\.map\([^)]*\.id\s*\)",
         index_js,
-        re.DOTALL,
     ), "the all-memes view must persist its global order through reorder_memes"
 
     normal_card_selector = (
@@ -757,77 +758,8 @@ def test_sorting_visual_feedback_static_contract():
 
 def test_grid_slot_hit_testing_stays_aligned_when_layout_moves_and_scrolls():
     root = Path(__file__).resolve().parent.parent
-    probe = r"""
-const fs = require('fs');
-const vm = require('vm');
-
-const source = fs.readFileSync('src/webui/index.js', 'utf8');
-const start = source.indexOf('function memeCardsInGrid()');
-const end = source.indexOf('function moveInArray(', start);
-if (start < 0 || end < 0) throw new Error('drag geometry helpers not found');
-
-const folder = { classList: { contains: name => name === 'folder-card' } };
-const meme = () => ({
-  offsetWidth: 100,
-  offsetHeight: 80,
-  classList: { contains: () => false },
-});
-const memes = [meme(), meme(), meme(), meme(), meme()];
-const allCards = [folder, ...memes];
-const layout = { left: 200, top: 100 };
-const grid = {
-  clientLeft: 0,
-  clientTop: 0,
-  clientWidth: 340,
-  getBoundingClientRect: () => ({ left: layout.left, top: layout.top }),
-};
-folder.offsetLeft = 218;
-folder.offsetTop = 110;
-
-const context = {
-  document: {
-    getElementById: id => {
-      if (id !== 'meme-grid') throw new Error('unexpected element id: ' + id);
-      return grid;
-    },
-    querySelectorAll: selector => selector.includes(':not(.folder-card)') ? memes : allCards,
-  },
-  getComputedStyle: () => ({
-    paddingLeft: '10px',
-    paddingRight: '10px',
-    paddingTop: '10px',
-    columnGap: '10px',
-    rowGap: '20px',
-  }),
-};
-vm.createContext(context);
-vm.runInContext(source.slice(start, end), context);
-
-function assertSlot(label, x, y, expected) {
-  const actual = context.gridSlotIndex(x, y);
-  if (actual !== expected) {
-    throw new Error(label + ': expected meme index ' + expected + ', got ' + actual);
-  }
-}
-
-function assertVisibleSlots(label) {
-  const originX = layout.left + 10;
-  const originY = layout.top + 10;
-  assertSlot(label + ' first meme after folder', originX + 110 + 50, originY + 40, 0);
-  assertSlot(label + ' third meme on next row', originX + 50, originY + 100 + 40, 2);
-}
-
-assertVisibleSlots('expanded sidebar');
-layout.left = 20;
-assertVisibleSlots('collapsed sidebar');
-layout.top = -90;
-assertVisibleSlots('scrolled grid');
-assertSlot('head clamp', -1000, -1000, 0);
-assertSlot('tail clamp', 10000, 10000, 4);
-console.log('grid slot behavior: PASS');
-"""
     result = subprocess.run(
-        ["node", "-e", probe],
+        ["node", root / "tests" / "fixtures" / "grid_slot_probe.js"],
         cwd=root,
         capture_output=True,
         text=True,

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -457,6 +457,11 @@ def test_sorting_visual_feedback_static_contract():
     index_js = (root / "src" / "webui" / "index.js").read_text(encoding="utf-8")
     index_css = (root / "src" / "webui" / "index.css").read_text(encoding="utf-8")
 
+    assert re.search(
+        r"let\s+collections\s*=\s*\[\]\s*,\s*activeCollection\s*=\s*null\s*;",
+        index_js,
+    ), "the initial view must remain the all-memes view"
+
     grid_wrap = re.search(r"#grid-wrap\s*\{(?:(?!\}).)*?\}", index_css, re.DOTALL)
     assert grid_wrap, "grid wrapper styles must remain locally inspectable"
     assert re.search(r"overflow-y\s*:\s*scroll", grid_wrap.group(0))
@@ -538,7 +543,10 @@ def test_sorting_visual_feedback_static_contract():
     assert re.search(
         r"if\s*\(\s*!dragSortEnabled\s*\)\s*return\s*false", can_reorder_body
     )
-    assert re.search(r"return\s+activeCollection\s*>\s*0", can_reorder_body)
+    assert re.search(
+        r"return\s+activeCollection\s*===\s*null\s*\|\|\s*" r"activeCollection\s*>\s*0",
+        can_reorder_body,
+    )
     assert re.search(
         r"if\s*\(\s*activeCollection\s*>\s*0\s*\)\s*\{\s*"
         r"ok\s*=\s*await\s+api\(\s*['\"]reorder_collection_members['\"]\s*,\s*"
@@ -546,6 +554,12 @@ def test_sorting_visual_feedback_static_contract():
         index_js,
         re.DOTALL,
     ), "sortable collections must persist their member order through the active collection"
+    assert re.search(
+        r"else\s*\{\s*ok\s*=\s*await\s+api\(\s*['\"]reorder_memes['\"]\s*,\s*"
+        r"memes\.map\(\s*x\s*=>\s*x\.id\s*\)",
+        index_js,
+        re.DOTALL,
+    ), "the all-memes view must persist its global order through reorder_memes"
 
     normal_card_selector = (
         "#meme-grid.sort-enabled .meme-card:not(.folder-card):not(.dragging)"

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -742,7 +743,6 @@ def test_sorting_visual_feedback_static_contract():
     assert re.search(r"x\s*-\s*originX", grid_slot_body)
     assert re.search(r"y\s*-\s*originY", grid_slot_body)
     assert not re.search(r"gRect\.left|gRect\.top", grid_slot_body)
-
     initial_append = re.search(
         r"memes\.forEach\(\s*m\s*=>\s*grid\.appendChild\(\s*renderMemeCard\(\s*m\s*\)\s*\)\s*\)",
         render_grid_body,
@@ -753,6 +753,89 @@ def test_sorting_visual_feedback_static_contract():
         layout_read,
         render_grid_body[initial_append.end() : initial_animation.start()],
     ), "initial sort baseline must commit layout before requestAnimationFrame"
+
+
+def test_grid_slot_hit_testing_stays_aligned_when_layout_moves_and_scrolls():
+    root = Path(__file__).resolve().parent.parent
+    probe = r"""
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('src/webui/index.js', 'utf8');
+const start = source.indexOf('function memeCardsInGrid()');
+const end = source.indexOf('function moveInArray(', start);
+if (start < 0 || end < 0) throw new Error('drag geometry helpers not found');
+
+const folder = { classList: { contains: name => name === 'folder-card' } };
+const meme = () => ({
+  offsetWidth: 100,
+  offsetHeight: 80,
+  classList: { contains: () => false },
+});
+const memes = [meme(), meme(), meme(), meme(), meme()];
+const allCards = [folder, ...memes];
+const layout = { left: 200, top: 100 };
+const grid = {
+  clientLeft: 0,
+  clientTop: 0,
+  clientWidth: 340,
+  getBoundingClientRect: () => ({ left: layout.left, top: layout.top }),
+};
+folder.offsetLeft = 218;
+folder.offsetTop = 110;
+
+const context = {
+  document: {
+    getElementById: id => {
+      if (id !== 'meme-grid') throw new Error('unexpected element id: ' + id);
+      return grid;
+    },
+    querySelectorAll: selector => selector.includes(':not(.folder-card)') ? memes : allCards,
+  },
+  getComputedStyle: () => ({
+    paddingLeft: '10px',
+    paddingRight: '10px',
+    paddingTop: '10px',
+    columnGap: '10px',
+    rowGap: '20px',
+  }),
+};
+vm.createContext(context);
+vm.runInContext(source.slice(start, end), context);
+
+function assertSlot(label, x, y, expected) {
+  const actual = context.gridSlotIndex(x, y);
+  if (actual !== expected) {
+    throw new Error(label + ': expected meme index ' + expected + ', got ' + actual);
+  }
+}
+
+function assertVisibleSlots(label) {
+  const originX = layout.left + 10;
+  const originY = layout.top + 10;
+  assertSlot(label + ' first meme after folder', originX + 110 + 50, originY + 40, 0);
+  assertSlot(label + ' third meme on next row', originX + 50, originY + 100 + 40, 2);
+}
+
+assertVisibleSlots('expanded sidebar');
+layout.left = 20;
+assertVisibleSlots('collapsed sidebar');
+layout.top = -90;
+assertVisibleSlots('scrolled grid');
+assertSlot('head clamp', -1000, -1000, 0);
+assertSlot('tail clamp', 10000, 10000, 4);
+console.log('grid slot behavior: PASS');
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "grid slot behavior: PASS"
 
 
 def test_webui_safe_serve_filename():


### PR DESCRIPTION
## Summary

- Enable drag sorting in the all-memes view while preserving collection-specific persistence.
- Calculate insertion slots in viewport coordinates using grid borders, padding, and independent row/column gaps.
- Add regression coverage for sidebar movement, scrolling, folder placeholders, and boundary clamping.

## Verification

- Startup tests: 30 passed.
- Ruff check passed.
- Black check passed.
- Node syntax check passed for src/webui/index.js.
- Chromium pointer QA passed with the sidebar expanded, collapsed, and the grid scrolled.

## Notes

- The full suite has 172 passing tests and one pre-existing Windows IP_PKTINFO environment failure unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持在“全部表情包”视图中直接调整表情包顺序。
  - 未选择分组时，也可参与表情包排序。
- **问题修复**
  - 优化网格布局计算，提升不同内边距、行列间距下的显示准确性。
  - 修复侧栏折叠、滚动及边界位置拖拽时的命中判断问题，使移动操作更稳定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->