### PR TITLE
feat(webui): 默认收起侧边栏并关闭排序

### DIFF
--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -11,7 +11,7 @@
   <div id="titlebar">
     <div class="logo">OhMy<span>Meme</span></div>
     <span class="spacer"></span>
-    <button id="drag-sort-toggle" class="icon-btn sort-on" onclick="toggleDragSort()" title="拖拽排序（开启=网格内排序，关闭=可拖拽表情到聊天窗口）">
+    <button id="drag-sort-toggle" class="icon-btn sort-off" onclick="toggleDragSort()" title="拖拽排序（开启=网格内排序，关闭=可拖拽表情到聊天窗口）">
       <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path d="M338.133333 725.333333l-82.133333 82.133334V648.533333a42.666667 42.666667 0 0 0-85.333333 0v204.8A42.666667 42.666667 0 0 0 213.333333 896h204.8a42.666667 42.666667 0 0 0 0-85.333333H298.666667l82.133333-82.133334a42.666667 42.666667 0 0 0-42.666667-3.2zM853.333333 170.666667H648.533333a42.666667 42.666667 0 0 0 0 85.333333h120.32l-82.133333 82.133333a42.666667 42.666667 0 0 0 3.2 63.573334A42.666667 42.666667 0 0 0 725.333333 426.666667l0 0a42.666667 42.666667 0 0 0 29.866667-12.8l130.986667-130.986667V413.866667a42.666667 42.666667 0 0 0 85.333333 0V213.333333a42.666667 42.666667 0 0 0-118.186667-42.666666zM307.2 298.666667a42.666667 42.666667 0 0 0-12.8 3.2L163.413333 432.853333V341.333333a42.666667 42.666667 0 0 0-85.333333 0v204.8a42.666667 42.666667 0 0 0 42.666667 42.666667h204.8a42.666667 42.666667 0 0 0 0-85.333333H217.6l82.133333-82.133334a42.666667 42.666667 0 0 0 3.2-63.573333A42.666667 42.666667 0 0 0 307.2 298.666667zM896 610.133333a42.666667 42.666667 0 0 0-85.333333 0v120.32l-82.133334-82.133333a42.666667 42.666667 0 0 0-63.573333-3.2 42.666667 42.666667 0 0 0 0 66.773333l130.986667 130.986667H682.666667a42.666667 42.666667 0 0 0 0 85.333333h213.333333a42.666667 42.666667 0 0 0 42.666667-42.666667V610.133333z"/></svg>
     </button>
     <button class="icon-btn" onclick="syncUpload()" title="上传到远端">
@@ -33,13 +33,13 @@
     <input id="search" type="text" placeholder="搜索表情包..." oninput="onSearch()" autofocus spellcheck="false">
   </div>
   <div id="content">
-    <div id="sidebar">
+    <div id="sidebar" class="collapsed">
       <div id="sidebar-header">
         <span>分组</span>
       </div>
       <div id="tree"></div>
     </div>
-    <button id="sidebar-toggle" onclick="toggleSidebar()" title="折叠/展开侧边栏">◀</button>
+    <button id="sidebar-toggle" class="collapsed" onclick="toggleSidebar()" title="折叠/展开侧边栏">▶</button>
     <div id="main">
       <div id="tagbar"></div>
       <div id="grid-wrap">

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -355,13 +355,16 @@ let memeDrag = null;
 let ignoreClick = false;
 let dragSortEnabled = false;
 
+function renderDragSortToggle() {
+  const btn = document.getElementById('drag-sort-toggle');
+  if (!btn) return;
+  btn.classList.toggle('sort-on', dragSortEnabled);
+  btn.classList.toggle('sort-off', !dragSortEnabled);
+}
+
 function toggleDragSort() {
   dragSortEnabled = !dragSortEnabled;
-  const btn = document.getElementById('drag-sort-toggle');
-  if (btn) {
-    btn.classList.toggle('sort-on', dragSortEnabled);
-    btn.classList.toggle('sort-off', !dragSortEnabled);
-  }
+  renderDragSortToggle();
   if (dragSortEnabled) {
     refreshMemes();
   } else {
@@ -1473,12 +1476,20 @@ async function syncDownload() {
 function hide() { try { pywebview.api.hide_window(); } catch(e) {} }
 function openSettings() { try { pywebview.api.open_settings(); } catch(e) {} }
 function focusSearch() { document.getElementById('search')?.focus(); }
-function toggleSidebar() {
+let sidebarCollapsed = true;
+
+function renderSidebarState() {
   const sb = document.getElementById('sidebar');
   const btn = document.getElementById('sidebar-toggle');
-  sb.classList.toggle('collapsed');
-  btn.classList.toggle('collapsed');
-  btn.textContent = sb.classList.contains('collapsed') ? '▶' : '◀';
+  if (!sb || !btn) return;
+  sb.classList.toggle('collapsed', sidebarCollapsed);
+  btn.classList.toggle('collapsed', sidebarCollapsed);
+  btn.textContent = sidebarCollapsed ? '▶' : '◀';
+}
+
+function toggleSidebar() {
+  sidebarCollapsed = !sidebarCollapsed;
+  renderSidebarState();
 }
 
 /* Drag-and-drop import */
@@ -1614,6 +1625,8 @@ function initHScroll(barId) {
 
 /* Init */
 document.addEventListener('DOMContentLoaded', async () => {
+  renderDragSortToggle();
+  renderSidebarState();
   initDragReorder();
   initHScroll('tagbar');
   const gridWrap = document.getElementById('grid-wrap');

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -353,7 +353,7 @@ function renderMemeCard(m) {
  * Pointer Events + 指针捕获，网格感知插入点，FLIP 让位动画 */
 let memeDrag = null;
 let ignoreClick = false;
-let dragSortEnabled = true;
+let dragSortEnabled = false;
 
 function toggleDragSort() {
   dragSortEnabled = !dragSortEnabled;


### PR DESCRIPTION
## 变更\n- 默认启动时收起侧边栏\n- 默认关闭拖拽排序模式\n\n## 验证\n- node --check src/webui/index.js\n- 浏览器首帧确认侧边栏宽度为 0px，排序按钮为关闭状态

## Summary by Sourcery

为网页界面设置新的默认 UI 状态：启动时侧边栏为折叠状态，并关闭拖拽排序模式。

新功能：
- 默认以折叠侧边栏的状态启动网页界面。
- 将拖拽排序切换初始化为关闭状态，这样在加载时拖拽排序处于禁用状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Set new default UI state for the web interface to start with a collapsed sidebar and drag-sort mode disabled.

New Features:
- Start the web UI with the sidebar collapsed by default.
- Initialize the drag-sort toggle in the off state so drag sorting is disabled on load.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **体验改进**
  - 拖拽排序默认关闭，避免页面初始状态下意外调整项目顺序。
  - 侧边栏默认收起，界面更加简洁。
  - 更新侧边栏切换按钮图标，使其更准确地表示展开方向。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->