### PR TITLE
fix(webui): 修复 Vue 重构遗漏的刷新入口与原生对话框残留

### DIFF
--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -7,6 +7,7 @@ import { useCollectionBuilder } from './composables/useCollectionBuilder'
 import ContextMenu from './components/ContextMenu.vue'
 import CollectionBuilder from './components/CollectionBuilder.vue'
 import CollectionTreeNode from './components/CollectionTreeNode.vue'
+import ConfirmDialog from './components/ConfirmDialog.vue'
 import ImportMenu from './components/ImportMenu.vue'
 import InputDialog from './components/InputDialog.vue'
 import Pager from './components/Pager.vue'
@@ -21,6 +22,12 @@ const cb = useCollectionBuilder()
 const tagEditor = ref<InstanceType<typeof TagEditor> | null>(null)
 const updateDialog = ref<InstanceType<typeof UpdateDialog> | null>(null)
 const inputDialog = ref<InstanceType<typeof InputDialog> | null>(null)
+const confirmDialog = ref<InstanceType<typeof ConfirmDialog> | null>(null)
+
+// 统一确认对话框（替代原生 confirm，风格与重构主题一致）
+async function confirmAsk(title: string, message: string): Promise<boolean> {
+  return !!(await confirmDialog.value?.open(title, message))
+}
 
 // 检查更新并弹窗（与原始实现一致）
 async function checkUpdateAndPrompt() {
@@ -61,6 +68,10 @@ function dismissStartupAnim() {
 onMounted(() => {
   // 兜底：视频加载失败或未触发 ended 时最多 6s 后移除遮罩，避免卡死界面
   startupAnimTimer = setTimeout(dismissStartupAnim, 6000)
+  // 后端 evaluate_js 刷新入口（设置保存/同步后由 webui.py 调用）
+  window.refreshMemes = () => { search() }
+  window.refreshTags = refreshTags
+  window.refreshCollections = refreshCollections
 })
 // 网格列数随侧边栏即时切换（实时感）；性能由卡片 content-visibility 保证
 const gridCols = computed(() => sidebarCollapsed.value ? 5 : 4)
@@ -315,7 +326,7 @@ async function onCtxAction(action: string) {
       search()
       break
     }
-    case 'collection': { showCollectionBuilder(); break }
+    case 'collection': { showCollectionBuilder(t.memeId); break }
     case 'add-to-subgroup': { /* 子菜单在 hover 时加载，点击走 subgroup-N / __new-subgroup__ */ break }
     case '__new-subgroup__': {
       const isSub = state.activeCollection && state.activeCollection > 0
@@ -357,7 +368,7 @@ async function onCtxAction(action: string) {
       break
     }
     case 'delete': {
-      if (confirm('确定删除这个表情包吗？')) { await window.pywebview?.api?.delete_meme(t.memeId); search(); refreshCollections() }
+      if (await confirmAsk('删除表情包', '确定删除这个表情包吗？')) { await window.pywebview?.api?.delete_meme(t.memeId); search(); refreshCollections() }
       break
     }
     case 'rename-collection': {
@@ -366,7 +377,7 @@ async function onCtxAction(action: string) {
       break
     }
     case 'delete-collection': {
-      if (confirm('确定删除这个分组吗？')) {
+      if (await confirmAsk('删除分组', '确定删除这个分组吗？')) {
         // 先移除组内表情到上层，再删组
         const parent = findParentCollection(state.collections, t.folderId)
         const members = (await window.pywebview?.api?.search_memes('', [], t.folderId, 0, 9999)) || []
@@ -380,7 +391,7 @@ async function onCtxAction(action: string) {
       break
     }
     case 'delete-folder': {
-      if (confirm('确定删除小分组「' + t.folderName + '」？分组内表情包将移回上层分组。')) {
+      if (await confirmAsk('删除小分组', '确定删除小分组「' + t.folderName + '」？分组内表情包将移回上层分组。')) {
         const parent = findParentCollection(state.collections, t.folderId)
         const members = (await window.pywebview?.api?.search_memes('', [], t.folderId, 0, 9999)) || []
         for (const mm of members) {
@@ -393,7 +404,7 @@ async function onCtxAction(action: string) {
       break
     }
     case 'clear-recent': {
-      if (confirm('确定清空最近使用记录吗？')) {
+      if (await confirmAsk('清空最近使用', '确定清空最近使用记录吗？')) {
         await window.pywebview?.api?.clear_recent()
         search()
       }
@@ -437,7 +448,7 @@ function findCollectionNode(items: any[], target: number): any | null {
   return null
 }
 
-async function showCollectionBuilder() {
+async function showCollectionBuilder(memeId?: number) {
   cb.open(async (confirm) => {
     const { name, memeIds, existingId } = confirm
     // 已选已有分组 → 更新其成员；否则新建分组
@@ -450,7 +461,7 @@ async function showCollectionBuilder() {
     } else {
       showToast(result?.error || '保存失败')
     }
-  })
+  }, memeId ? [memeId] : [])
 }
 
 const hoverTimers = new Map<number, ReturnType<typeof setTimeout>>()
@@ -799,6 +810,7 @@ onUnmounted(() => {
   <TagEditor ref="tagEditor" />
   <UpdateDialog ref="updateDialog" />
   <InputDialog ref="inputDialog" />
+  <ConfirmDialog ref="confirmDialog" />
   <ContextMenu
     :visible="ctx.visible.value" :x="ctx.x.value" :y="ctx.y.value"
     :items="ctx.items.value" :trigger="ctx.trigger.value"

--- a/src/vue-src/components/CollectionBuilder.vue
+++ b/src/vue-src/components/CollectionBuilder.vue
@@ -86,9 +86,14 @@ const cb = useCollectionBuilder()
         </div>
       </div>
 
+      <div v-if="cb.memberLoadError.value" class="cb-error">
+        <span>分组信息加载失败，请重试</span>
+        <button class="btn btn-sm btn-secondary" @click="cb.retryLoadMembers()">重试</button>
+      </div>
+
       <div class="cb-footer">
         <button class="btn btn-secondary" @click="cb.close()">取消</button>
-        <button class="btn btn-primary" :disabled="cb.memberLoading.value || !cb.collectionName.value.trim()" @click="cb.confirm()">{{ cb.selectedId.value != null ? '保存到该分组' : '创建分组' }}</button>
+        <button class="btn btn-primary" :disabled="cb.memberLoading.value || cb.memberLoadError.value || !cb.collectionName.value.trim()" @click="cb.confirm()">{{ cb.selectedId.value != null ? '保存到该分组' : '创建分组' }}</button>
       </div>
     </div>
   </div>
@@ -312,6 +317,18 @@ const cb = useCollectionBuilder()
   text-align: center;
   font-size: 12px;
   color: var(--muted);
+}
+
+.cb-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 20px;
+  font-size: 12px;
+  color: var(--danger, #dc2626);
+  background: rgba(220, 38, 38, 0.08);
+  border-top: 1px solid var(--border);
 }
 
 .cb-footer {

--- a/src/vue-src/components/CollectionBuilder.vue
+++ b/src/vue-src/components/CollectionBuilder.vue
@@ -20,14 +20,17 @@ const cb = useCollectionBuilder()
             @focus="cb.showDropdown.value = true"
           />
           <div v-if="cb.showDropdown.value" id="cb-dropdown" class="cb-dropdown show">
+            <div class="cb-dd-section" v-if="cb.collectionName.value.trim() || cb.selectedId.value == null">新建分组</div>
             <div v-if="cb.collectionName.value.trim()" class="cb-dd-item cb-dd-new-item" @click="cb.createNew()">
               <span class="cb-dd-new">「{{ cb.collectionName.value }}」</span>
-              <span class="cb-dd-hint">新建分组</span>
+              <span class="cb-dd-hint">创建新分组</span>
             </div>
+            <div class="cb-dd-section">加入已有分组</div>
             <div
               v-for="opt in cb.collectionOptions.value"
               :key="opt.id"
               class="cb-dd-item"
+              :class="{ 'cb-dd-selected': cb.selectedId.value === opt.id }"
               @click="cb.selectCollection(opt)"
             >
               {{ opt.name }}
@@ -85,7 +88,7 @@ const cb = useCollectionBuilder()
 
       <div class="cb-footer">
         <button class="btn btn-secondary" @click="cb.close()">取消</button>
-        <button class="btn btn-primary" :disabled="!cb.collectionName.value.trim()" @click="cb.confirm()">确定</button>
+        <button class="btn btn-primary" :disabled="!cb.collectionName.value.trim()" @click="cb.confirm()">{{ cb.selectedId.value ? '保存到该分组' : '创建分组' }}</button>
       </div>
     </div>
   </div>
@@ -167,6 +170,21 @@ const cb = useCollectionBuilder()
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.cb-dd-section {
+  padding: 5px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  background: var(--surface-2);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.cb-dd-selected {
+  color: var(--primary);
+  font-weight: 600;
 }
 
 .cb-dd-item:hover {

--- a/src/vue-src/components/CollectionBuilder.vue
+++ b/src/vue-src/components/CollectionBuilder.vue
@@ -88,7 +88,7 @@ const cb = useCollectionBuilder()
 
       <div class="cb-footer">
         <button class="btn btn-secondary" @click="cb.close()">取消</button>
-        <button class="btn btn-primary" :disabled="!cb.collectionName.value.trim()" @click="cb.confirm()">{{ cb.selectedId.value ? '保存到该分组' : '创建分组' }}</button>
+        <button class="btn btn-primary" :disabled="cb.memberLoading.value || !cb.collectionName.value.trim()" @click="cb.confirm()">{{ cb.selectedId.value != null ? '保存到该分组' : '创建分组' }}</button>
       </div>
     </div>
   </div>

--- a/src/vue-src/components/ConfirmDialog.vue
+++ b/src/vue-src/components/ConfirmDialog.vue
@@ -24,8 +24,8 @@ function close(v: boolean) {
 }
 
 function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Enter') { e.preventDefault(); close(true) }
-  else if (e.key === 'Escape') { e.stopPropagation(); close(false) }
+  // 危险操作不响应 Enter 自动确认，避免误触；Escape 取消
+  if (e.key === 'Escape') { e.stopPropagation(); close(false) }
 }
 
 defineExpose({ open })
@@ -33,9 +33,9 @@ defineExpose({ open })
 
 <template>
   <div v-if="visible" class="confirm-dialog-overlay" @click.self="close(false)">
-    <div class="confirm-dialog-box" @keydown="onKeydown">
-      <div class="confirm-dialog-title">{{ title }}</div>
-      <div class="confirm-dialog-message">{{ message }}</div>
+    <div class="confirm-dialog-box" role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title" aria-describedby="confirm-dialog-message" @keydown="onKeydown">
+      <div id="confirm-dialog-title" class="confirm-dialog-title">{{ title }}</div>
+      <div id="confirm-dialog-message" class="confirm-dialog-message">{{ message }}</div>
       <div class="confirm-dialog-actions">
         <button ref="confirmEl" class="btn btn-danger" @click="close(true)">确定</button>
         <button class="btn btn-secondary" @click="close(false)">取消</button>

--- a/src/vue-src/components/ConfirmDialog.vue
+++ b/src/vue-src/components/ConfirmDialog.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { ref, nextTick } from 'vue'
+
+const visible = ref(false)
+const title = ref('')
+const message = ref('')
+const confirmEl = ref<HTMLButtonElement>()
+
+let resolveFn: ((v: boolean) => void) | null = null
+
+async function open(t: string, msg: string): Promise<boolean> {
+  if (resolveFn) { resolveFn(false); resolveFn = null }
+  title.value = t
+  message.value = msg
+  visible.value = true
+  await nextTick()
+  confirmEl.value?.focus()
+  return new Promise(resolve => { resolveFn = resolve })
+}
+
+function close(v: boolean) {
+  visible.value = false
+  if (resolveFn) { resolveFn(v); resolveFn = null }
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter') { e.preventDefault(); close(true) }
+  else if (e.key === 'Escape') { e.stopPropagation(); close(false) }
+}
+
+defineExpose({ open })
+</script>
+
+<template>
+  <div v-if="visible" class="confirm-dialog-overlay" @click.self="close(false)">
+    <div class="confirm-dialog-box" @keydown="onKeydown">
+      <div class="confirm-dialog-title">{{ title }}</div>
+      <div class="confirm-dialog-message">{{ message }}</div>
+      <div class="confirm-dialog-actions">
+        <button ref="confirmEl" class="btn btn-danger" @click="close(true)">确定</button>
+        <button class="btn btn-secondary" @click="close(false)">取消</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.confirm-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 260;
+  animation: fadeIn 0.15s ease;
+}
+
+.confirm-dialog-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px 24px;
+  width: 360px;
+  box-shadow: var(--shadow-lg);
+}
+
+.confirm-dialog-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 8px;
+}
+
+.confirm-dialog-message {
+  font-size: 13px;
+  color: var(--fg-secondary);
+  line-height: 1.6;
+  margin-bottom: 16px;
+}
+
+.confirm-dialog-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+</style>

--- a/src/vue-src/composables/useCollectionBuilder.ts
+++ b/src/vue-src/composables/useCollectionBuilder.ts
@@ -35,6 +35,8 @@ const selectedName = ref('')
 const preselectIds = ref<number[]>([])
 // 已有分组成员加载中：期间禁用确认，避免以不完整的成员集提交
 const memberLoading = ref(false)
+// 分组成员加载失败：保留现有选择、禁用确认，提供重试
+const memberLoadError = ref(false)
 
 let onConfirmCallback: ((result: CollectionConfirm) => void) | null = null
 let memberReqGen = 0
@@ -43,6 +45,9 @@ export function useCollectionBuilder() {
   async function open(onConfirm: (result: CollectionConfirm) => void, preselect: number[] = []) {
     onConfirmCallback = onConfirm
     preselectIds.value = preselect
+    memberReqGen++
+    memberLoading.value = false
+    memberLoadError.value = false
     visible.value = true
     loading.value = true
     searchQuery.value = ''
@@ -66,6 +71,9 @@ export function useCollectionBuilder() {
   }
 
   function close() {
+    memberReqGen++
+    memberLoading.value = false
+    memberLoadError.value = false
     visible.value = false
     showDropdown.value = false
   }
@@ -77,42 +85,60 @@ export function useCollectionBuilder() {
     selectedIds.value = newSet
   }
 
+  function loadMembers(cid: number) {
+    const gen = ++memberReqGen
+    memberLoading.value = true
+    memberLoadError.value = false
+    api('get_collection_members', cid).then((members: any) => {
+      if (gen !== memberReqGen || cid !== selectedId.value) return
+      memberLoading.value = false
+      if (members == null) {
+        // 加载失败：保留现有选择，标记错误并阻止提交不完整的成员集
+        memberLoadError.value = true
+        return
+      }
+      const ids = new Set((members || []).map((m: any) => m.id))
+      preselectIds.value.forEach(id => ids.add(id))
+      selectedIds.value = ids
+    })
+  }
+
   function selectCollection(opt: CollectionOption) {
     selectedId.value = opt.id
     selectedName.value = opt.name
     collectionName.value = opt.name
     showDropdown.value = false
     // 已有分组：加载其现有成员，并保留预选的表情（右键带入的新增项）
-    const gen = ++memberReqGen
-    memberLoading.value = true
-    api('get_collection_members', opt.id).then((members: any) => {
-      if (gen !== memberReqGen) return
-      memberLoading.value = false
-      const ids = new Set((members || []).map((m: any) => m.id))
-      preselectIds.value.forEach(id => ids.add(id))
-      selectedIds.value = ids
-    })
+    loadMembers(opt.id)
   }
   function createNew() {
     memberReqGen++
     memberLoading.value = false
+    memberLoadError.value = false
     selectedId.value = null
     selectedName.value = ''
     collectionName.value = ''
     selectedIds.value = new Set(preselectIds.value)
     showDropdown.value = false
   }
+  function retryLoadMembers() {
+    if (selectedId.value != null) loadMembers(selectedId.value)
+  }
 
-  // 用户手动改输入框文字 → 视为新建分组，取消已选分组
+  // 用户手动改输入框文字 → 视为新建分组，取消已选分组并恢复预选
   watch(collectionName, (val) => {
     if (selectedId.value != null && val !== selectedName.value) {
+      memberReqGen++
+      memberLoading.value = false
+      memberLoadError.value = false
       selectedId.value = null
+      selectedIds.value = new Set(preselectIds.value)
     }
   })
 
   function confirm() {
     const name = collectionName.value.trim()
-    if (!name || memberLoading.value) return
+    if (!name || memberLoading.value || memberLoadError.value) return
     const memeIds = Array.from(selectedIds.value)
     if (onConfirmCallback) {
       onConfirmCallback({ name, memeIds, existingId: selectedId.value })
@@ -149,6 +175,7 @@ export function useCollectionBuilder() {
     visible,
     loading,
     memberLoading,
+    memberLoadError,
     searchQuery,
     selectedIds,
     selectedId,
@@ -162,6 +189,7 @@ export function useCollectionBuilder() {
     toggleMeme,
     selectCollection,
     createNew,
+    retryLoadMembers,
     confirm,
   }
 }

--- a/src/vue-src/composables/useCollectionBuilder.ts
+++ b/src/vue-src/composables/useCollectionBuilder.ts
@@ -31,16 +31,19 @@ const showDropdown = ref(false)
 // 已选中的已有分组 id（null = 新建分组）
 const selectedId = ref<number | null>(null)
 const selectedName = ref('')
+// 打开时预选的表情（右键「添加分组」带入），切换新建/已有分组时保留
+const preselectIds = ref<number[]>([])
 
 let onConfirmCallback: ((result: CollectionConfirm) => void) | null = null
 
 export function useCollectionBuilder() {
-  async function open(onConfirm: (result: CollectionConfirm) => void) {
+  async function open(onConfirm: (result: CollectionConfirm) => void, preselect: number[] = []) {
     onConfirmCallback = onConfirm
+    preselectIds.value = preselect
     visible.value = true
     loading.value = true
     searchQuery.value = ''
-    selectedIds.value = new Set()
+    selectedIds.value = new Set(preselect)
     collectionName.value = ''
     selectedId.value = null
     selectedName.value = ''
@@ -76,16 +79,18 @@ export function useCollectionBuilder() {
     selectedName.value = opt.name
     collectionName.value = opt.name
     showDropdown.value = false
+    // 已有分组：加载其现有成员，并保留预选的表情（右键带入的新增项）
     api('get_collection_members', opt.id).then((members: any) => {
-      selectedIds.value = new Set((members || []).map((m: any) => m.id))
+      const ids = new Set((members || []).map((m: any) => m.id))
+      preselectIds.value.forEach(id => ids.add(id))
+      selectedIds.value = ids
     })
   }
-
   function createNew() {
     selectedId.value = null
     selectedName.value = ''
     collectionName.value = ''
-    selectedIds.value = new Set()
+    selectedIds.value = new Set(preselectIds.value)
     showDropdown.value = false
   }
 
@@ -136,6 +141,7 @@ export function useCollectionBuilder() {
     loading,
     searchQuery,
     selectedIds,
+    selectedId,
     collectionName,
     collectionOptions,
     showDropdown,

--- a/src/vue-src/composables/useCollectionBuilder.ts
+++ b/src/vue-src/composables/useCollectionBuilder.ts
@@ -33,8 +33,11 @@ const selectedId = ref<number | null>(null)
 const selectedName = ref('')
 // 打开时预选的表情（右键「添加分组」带入），切换新建/已有分组时保留
 const preselectIds = ref<number[]>([])
+// 已有分组成员加载中：期间禁用确认，避免以不完整的成员集提交
+const memberLoading = ref(false)
 
 let onConfirmCallback: ((result: CollectionConfirm) => void) | null = null
+let memberReqGen = 0
 
 export function useCollectionBuilder() {
   async function open(onConfirm: (result: CollectionConfirm) => void, preselect: number[] = []) {
@@ -80,13 +83,19 @@ export function useCollectionBuilder() {
     collectionName.value = opt.name
     showDropdown.value = false
     // 已有分组：加载其现有成员，并保留预选的表情（右键带入的新增项）
+    const gen = ++memberReqGen
+    memberLoading.value = true
     api('get_collection_members', opt.id).then((members: any) => {
+      if (gen !== memberReqGen) return
+      memberLoading.value = false
       const ids = new Set((members || []).map((m: any) => m.id))
       preselectIds.value.forEach(id => ids.add(id))
       selectedIds.value = ids
     })
   }
   function createNew() {
+    memberReqGen++
+    memberLoading.value = false
     selectedId.value = null
     selectedName.value = ''
     collectionName.value = ''
@@ -103,7 +112,7 @@ export function useCollectionBuilder() {
 
   function confirm() {
     const name = collectionName.value.trim()
-    if (!name) return
+    if (!name || memberLoading.value) return
     const memeIds = Array.from(selectedIds.value)
     if (onConfirmCallback) {
       onConfirmCallback({ name, memeIds, existingId: selectedId.value })
@@ -139,6 +148,7 @@ export function useCollectionBuilder() {
   return {
     visible,
     loading,
+    memberLoading,
     searchQuery,
     selectedIds,
     selectedId,

--- a/src/vue-src/main.ts
+++ b/src/vue-src/main.ts
@@ -5,6 +5,11 @@ import './style.css'
 declare global {
   interface Window {
     pywebview: any
+    focusSearch: () => void
+    refreshMemes: () => void
+    refreshTags: () => void
+    refreshCollections: () => void
+    showLanDeviceConfirm: (device: any) => void
   }
 }
 
@@ -13,6 +18,48 @@ window.focusSearch = () => {
   const el = document.getElementById('search')
   if (el) el.focus()
 }
+
+// 后端 LAN 设备连接确认：_lan_confirm_cb 通过 evaluate_js("showLanDeviceConfirm(...)") 调用。
+// 用户允许/拒绝后回传 lan_confirm_device，超时未确认时后端默认拒绝。
+function showLanDeviceConfirm(device: any) {
+  if (document.getElementById('lan-confirm-overlay')) return
+  const esc = (s: any) =>
+    String(s ?? '').replace(
+      /[&<>"']/g,
+      c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string)
+    )
+  const overlay = document.createElement('div')
+  overlay.id = 'lan-confirm-overlay'
+  overlay.style.cssText =
+    'position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;z-index:500;animation:fadeIn .15s'
+  const box = document.createElement('div')
+  box.style.cssText =
+    'background:var(--surface);border-radius:var(--radius-lg);padding:24px 28px;width:400px;border:1px solid var(--border);box-shadow:var(--shadow-lg)'
+  box.innerHTML =
+    '<div style="margin-bottom:14px"><h2 style="font-size:15px;font-weight:600;color:var(--fg);margin-bottom:8px">设备连接请求</h2>'
+    + '<p style="font-size:13px;color:var(--fg-secondary);line-height:1.6">以下设备请求连接本机 OhMyMeme：</p>'
+    + '<div style="background:var(--card);border:1px solid var(--border);border-radius:var(--radius-sm);padding:12px 14px;margin:12px 0;font-size:13px;line-height:1.8">'
+    + '<div><span style="color:var(--muted)">设备：</span><b style="color:var(--fg)">' + esc(device?.name || '未知设备') + '</b></div>'
+    + '<div><span style="color:var(--muted)">型号：</span><span style="color:var(--fg)">' + esc(device?.model || '-') + '</span></div>'
+    + '<div><span style="color:var(--muted)">系统：</span><span style="color:var(--fg)">' + esc(device?.os || '-') + '</span></div>'
+    + '<div><span style="color:var(--muted)">版本：</span><span style="color:var(--fg)">' + esc(device?.ver || '-') + '</span></div>'
+    + '</div>'
+    + '<p style="font-size:12px;color:var(--muted);line-height:1.6">允许后该设备可同步表情包与配置。请确认是你信任的设备。</p></div>'
+    + '<div style="display:flex;gap:8px;justify-content:flex-end">'
+    + '<button id="lan-confirm-deny" class="btn btn-secondary">拒绝</button>'
+    + '<button id="lan-confirm-allow" class="btn btn-primary">允许连接</button></div>'
+  overlay.appendChild(box)
+  document.body.appendChild(overlay)
+  const finish = (approved: boolean) => {
+    overlay.remove()
+    window.pywebview?.api?.lan_confirm_device(approved)
+  }
+  overlay.onclick = (e) => { if (e.target === overlay) finish(false) }
+  box.querySelector('#lan-confirm-deny')!.addEventListener('click', () => finish(false))
+  box.querySelector('#lan-confirm-allow')!.addEventListener('click', () => finish(true))
+}
+// 供 pywebview evaluate_js 调用（需为 window 全局）
+window.showLanDeviceConfirm = showLanDeviceConfirm
 
 const app = createApp(App)
 app.mount('#app-mount')

--- a/src/vue-src/main.ts
+++ b/src/vue-src/main.ts
@@ -33,6 +33,8 @@ function showLanDeviceConfirm(device: any) {
   overlay.style.cssText =
     'position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;z-index:500;animation:fadeIn .15s'
   const box = document.createElement('div')
+  box.setAttribute('role', 'dialog')
+  box.setAttribute('aria-modal', 'true')
   box.style.cssText =
     'background:var(--surface);border-radius:var(--radius-lg);padding:24px 28px;width:400px;border:1px solid var(--border);box-shadow:var(--shadow-lg)'
   box.innerHTML =

--- a/src/vue-src/style.css
+++ b/src/vue-src/style.css
@@ -812,6 +812,17 @@ body {
   border-color: transparent;
 }
 
+.btn-danger {
+  background: var(--danger, #dc2626);
+  border-color: var(--danger, #dc2626);
+  color: #fff;
+}
+
+.btn-danger:hover {
+  background: #b91c1c;
+  border-color: #b91c1c;
+}
+
 .btn-sm {
   padding: 5px 10px;
   font-size: 12px;

--- a/src/webui.py
+++ b/src/webui.py
@@ -1390,6 +1390,33 @@ class SettingsApi:
             "hover_to_play": d.get("hover_to_play", False),
         }
 
+    def refresh_memes(self) -> dict:
+        """设置窗口同步完成后刷新主窗口表情列表"""
+        try:
+            if len(webview.windows) > 0:
+                webview.windows[0].evaluate_js("refreshMemes();")
+        except Exception:
+            pass
+        return {"ok": True}
+
+    def refresh_tags(self) -> dict:
+        """设置窗口同步完成后刷新主窗口标签栏"""
+        try:
+            if len(webview.windows) > 0:
+                webview.windows[0].evaluate_js("refreshTags();")
+        except Exception:
+            pass
+        return {"ok": True}
+
+    def refresh_collections(self) -> dict:
+        """设置窗口同步完成后刷新主窗口分组树"""
+        try:
+            if len(webview.windows) > 0:
+                webview.windows[0].evaluate_js("refreshCollections();")
+        except Exception:
+            pass
+        return {"ok": True}
+
     def save_settings(self, settings: dict):
         if isinstance(settings, dict):
             if "auto_start" in settings:

--- a/src/webui.py
+++ b/src/webui.py
@@ -1390,32 +1390,26 @@ class SettingsApi:
             "hover_to_play": d.get("hover_to_play", False),
         }
 
-    def refresh_memes(self) -> dict:
+    def _safe_refresh(self, js_function: str) -> dict:
+        """执行前端刷新函数，并在异常时记录日志"""
+        try:
+            if len(webview.windows) > 0:
+                webview.windows[0].evaluate_js(f"{js_function}();")
+        except Exception:
+            logger.exception("前端刷新函数 %s 执行失败", js_function)
+        return {"ok": True}
+
+    def refresh_memes(self):
         """设置窗口同步完成后刷新主窗口表情列表"""
-        try:
-            if len(webview.windows) > 0:
-                webview.windows[0].evaluate_js("refreshMemes();")
-        except Exception:
-            pass
-        return {"ok": True}
+        return self._safe_refresh("refreshMemes")
 
-    def refresh_tags(self) -> dict:
+    def refresh_tags(self):
         """设置窗口同步完成后刷新主窗口标签栏"""
-        try:
-            if len(webview.windows) > 0:
-                webview.windows[0].evaluate_js("refreshTags();")
-        except Exception:
-            pass
-        return {"ok": True}
+        return self._safe_refresh("refreshTags")
 
-    def refresh_collections(self) -> dict:
+    def refresh_collections(self):
         """设置窗口同步完成后刷新主窗口分组树"""
-        try:
-            if len(webview.windows) > 0:
-                webview.windows[0].evaluate_js("refreshCollections();")
-        except Exception:
-            pass
-        return {"ok": True}
+        return self._safe_refresh("refreshCollections")
 
     def save_settings(self, settings: dict):
         if isinstance(settings, dict):

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -123,6 +123,8 @@ function showConfirm(title, message) {
     overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;z-index:200;animation:fadeIn .15s';
     overlay.onclick = (e) => { if (e.target === overlay) { overlay.remove(); resolve(false); } };
     const box = document.createElement('div');
+    box.setAttribute('role', 'dialog');
+    box.setAttribute('aria-modal', 'true');
     box.style.cssText = 'background:var(--surface);border-radius:var(--radius-lg);padding:24px 28px;width:400px;border:1px solid var(--border);box-shadow:var(--shadow-lg)';
     box.innerHTML = '<div style="margin-bottom:16px"><h2 style="font-size:15px;font-weight:600;color:var(--fg);margin-bottom:8px">' + esc(title) + '</h2><p style="font-size:13px;color:var(--fg-secondary);line-height:1.7;white-space:pre-line">' + esc(message) + '</p></div>'
       + '<div style="display:flex;gap:8px;justify-content:flex-end">'

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -117,10 +117,31 @@ async function checkConnectivity() {  // DeepSeek V4 Flash
 /* 局域网互联 */
 let lanPollTimer = null;
 
+function showConfirm(title, message) {
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+    overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;z-index:200;animation:fadeIn .15s';
+    overlay.onclick = (e) => { if (e.target === overlay) { overlay.remove(); resolve(false); } };
+    const box = document.createElement('div');
+    box.style.cssText = 'background:var(--surface);border-radius:var(--radius-lg);padding:24px 28px;width:400px;border:1px solid var(--border);box-shadow:var(--shadow-lg)';
+    box.innerHTML = '<div style="margin-bottom:16px"><h2 style="font-size:15px;font-weight:600;color:var(--fg);margin-bottom:8px">' + esc(title) + '</h2><p style="font-size:13px;color:var(--fg-secondary);line-height:1.7;white-space:pre-line">' + esc(message) + '</p></div>'
+      + '<div style="display:flex;gap:8px;justify-content:flex-end">'
+      + '<button id="sconfirm-cancel" class="btn btn-secondary">取消</button>'
+      + '<button id="sconfirm-ok" class="btn btn-primary">确定</button></div>';
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+    document.getElementById('sconfirm-ok').focus();
+    const cleanup = () => { overlay.remove(); };
+    document.getElementById('sconfirm-ok').onclick = () => { cleanup(); resolve(true); };
+    document.getElementById('sconfirm-cancel').onclick = () => { cleanup(); resolve(false); };
+    overlay.onkeydown = (e) => { if (e.key === 'Escape') { e.stopPropagation(); cleanup(); resolve(false); } };
+  });
+}
+
 async function toggleLanSecretConfig() {
   const cb = document.getElementById('s-lan-secret-config');
   if (cb.checked) {
-    const ok = confirm('请勿在公共网络或不信任的网络进行此操作！\n\n开启后配置同步将包含 FTP/S3/R2/WebDAV 等密钥字段，密钥将明文传输给局域网内配对设备。\n仅本次会话有效，不写入配置。是否继续？');
+    const ok = await showConfirm('允许密钥传输', '请勿在公共网络或不信任的网络进行此操作！\n\n开启后配置同步将包含 FTP/S3/R2/WebDAV 等密钥字段，密钥将明文传输给局域网内配对设备。\n仅本次会话有效，不写入配置。是否继续？');
     if (!ok) {
       cb.checked = false;
       return;


### PR DESCRIPTION
## 背景
Vue 3 主窗口重构（`24d5208`/`7307778`）遗留了两类问题：**后端到前端的通信入口在重构中丢失**，以及**对话框样式与重构主题不一致**。本次提交系统修复并统一。

## 修复内容

### 1. 修复互联/刷新功能的重构遗忘（3 处）
| 问题 | 根因 | 修复 |
|------|------|------|
| 手机-电脑互联被电脑端"拒绝连接" | `webui.py:_lan_confirm_cb` 通过 `evaluate_js("window.showLanDeviceConfirm(...)")` 弹确认窗，但 Vue 主窗口未定义该全局函数 → JS 抛错 → `except` 分支自动 `confirm_device(False)` | `main.ts` 补回 `window.showLanDeviceConfirm`（复刻旧 vanilla 实现，含 XSS 转义） |
| 同步/设置保存后主窗口不刷新 | 后端 5 处 `evaluate_js` 调用 `refreshMemes()/refreshTags()/refreshCollections()`，Vue 未定义这些全局函数 | `App.vue` `onMounted` 挂载三个全局刷新函数 |
| 设置窗口同步后主窗口不刷新 | `settings.js:739-741` 调用 `SettingsApi.refresh_memes/refresh_tags/refresh_collections`，后端从未定义 | `webui.py` `SettingsApi` 新增三个 `refresh_*` 方法 |

### 2. 统一对话框样式（替代原生系统弹窗）
| 位置 | 原实现 | 修复 |
|------|--------|------|
| `App.vue` 删除表情/分组/清空最近使用（4 处） | 原生 `confirm()` | 新增 `ConfirmDialog.vue`（`--surface` 主题、圆角卡片、危险操作红色确认按钮） |
| `settings.js` 密钥传输警示（1 处） | 原生 `confirm()` | 新增 `showConfirm()` 自定义对话框（多行文本 `pre-line` 渲染） |
| 全局样式 | 无危险按钮 | `style.css` 新增 `.btn-danger` |

### 3. 创建分组交互改进（顺带修复）
- 右键表情「添加分组」打开 CollectionBuilder 时**预选该表情**（原实现弹窗打开两栏全空，用户不知从何开始）
- 下拉改为「新建分组 / 加入已有分组」两节展示，选中已有分组高亮
- 选择已有分组时保留预选表情并合并现有成员；确认按钮文案随模式切换（`创建分组`/`保存到该分组`）

## 影响范围
```
 src/vue-src/App.vue                             |  26 +++++--
 src/vue-src/components/CollectionBuilder.vue    |  22 +++++-
 src/vue-src/components/ConfirmDialog.vue        |  92 ++++++++++++++++++
 src/vue-src/composables/useCollectionBuilder.ts |  16 +++--
 src/vue-src/main.ts                             |  47 +++++++++++++
 src/vue-src/style.css                           |  11 +++
 src/webui.py                                    |  27 ++++++++
 src/webui/settings.js                           |  23 ++++++-
 8 files changed, 249 insertions(+), 15 deletions(-)
```

## 验证
- `python -m pytest tests/` — **189 passed**（含 LAN 互联 31 项，覆盖设备确认链路）
- `ruff check src/`、`black --check src/` — 全部通过
- `npx vite build` — 构建成功，`dist/ohmymeme.js` JS 语法校验通过
- 前端产物 `dist/` 由 CI/构建自动生成（gitignored）

## 备注
- 无破坏性变更，改动均为修复重构回归 + 对话框样式统一
- 前端需在构建时自动编译 Vue（`build.py` 已处理）

## Summary by Sourcery

恢复缺失的后端到 Vue 的通信钩子，并将确认对话框统一为新的 Web UI 主题风格。

新功能：
- 为主窗口和设置界面中的破坏性操作添加主题化的确认对话框。
- 当从上下文菜单打开合集构建器时预先选中对应的 emoji，并支持合并到已有合集。

Bug 修复：
- 重新引入后端与 Vue 主窗口之间的局域网（LAN）设备确认处理。
- 在保存设置或同步后，恢复由后端触发的表情包（memes）、标签和合集的刷新钩子。

增强优化：
- 优化合集构建器下拉菜单，将创建新分组与加入现有分组分离开来，并使用更清晰的标签和选中高亮。
- 引入危险风格的按钮变体，以在涉及风险操作时提供一致的视觉强调效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore missing backend-to-Vue communication hooks and unify confirmation dialogs with the new Web UI theme.

New Features:
- Add themed confirmation dialogs for destructive actions in the main window and settings UI.
- Preselect emojis when opening the collection builder from the context menu and support merging into existing collections.

Bug Fixes:
- Reintroduce LAN device confirmation handling between backend and Vue main window.
- Restore backend-triggered refresh hooks for memes, tags, and collections after settings save or sync.

Enhancements:
- Refine collection builder dropdown to separate creating new groups from joining existing ones, with clearer labels and selection highlighting.
- Introduce a danger-styled button variant for consistent visual emphasis on risky actions.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增统一确认对话框，支持确认、取消、遮罩点击和 Escape 关闭。
  * 新增局域网设备连接确认提示，并展示设备信息。
  * 删除内容、清空记录及修改局域网设置时，改用统一确认界面。
  * 分组操作可预选当前表情包，支持创建或加入已有分组。
  * 新增表情包、标签和分组数据刷新能力。

* **界面优化**
  * 优化分组选择提示、按钮文案和选中状态。
  * 分组成员加载失败时显示错误提示，并支持重试。
  * 新增危险操作按钮样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->