### PR TITLE
fix(wechat/tg): 微信 helper 哈希配置 + Telegram 转换修复，发布 v0.6.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,7 +314,7 @@ tests/
 - **手动指定目录**: 设置页「手动指定 tdata 目录」按钮（`SettingsApi.pick_tg_tdata`）弹文件夹对话框，`is_valid_tdata()` 校验含 `key_datas`/`key_data`，通过后持久化到 config 键 `tg_tdata_path`（下次启动预填显示）；导入失败弹窗内 `error_code` 为 `no_tdata`/`invalid_tdata`/`no_cache` 时显示「手动选择 tdata 目录」重试按钮
 - **解密机制**: Telegram Desktop 缓存使用 AES-IGE（TDF$ 文件）和 AES-CTR（TDEF 文件）加密，本地密钥从 `tdata/key_datas` 读取，通过 PBKDF2-HMAC-SHA512 派生（有本地密码时 100k 迭代，无密码时 1 次）；`bad_key` 错误提示本地密码场景
 - **解密流程**: `read_local_key()` 读取密钥 → 遍历 `user_data/cache` + `user_data/media_cache` → `decrypt_tdf_file()`/`decrypt_tdef_file()` 按魔数识别格式解密 → `detect_extension()` 通过文件头识别扩展名 → 仅保留 webp/webm
-- **webm 转换** (`convert_webm_to_webp`): 默认开启，ffmpeg 将 webm 转 animated webp，**无损**（`-lossless 1 -quality 100`），保持宽高比（最长边 512，不放大），删除原 webm；转换前 `_check_ffmpeg()` 预检，缺失时报 `error_code="no_ffmpeg"` 中止；**单个转换失败的文件跳过不导入**（`convert_failed` 计数并在完成消息提示）
+- **webm 转换** (`convert_webm_to_webp`): 默认开启，ffmpeg 将 webm 转 animated webp，**有损 q80**（`-lossless 0 -quality 80`，无损编码实测 11-35s/个过慢改用有损，贴纸场景质量几乎无损），`-loop 1` 循环播放，保持宽高比（最长边 512，不放大），删除原 webm；转换前 `_check_ffmpeg()` 预检，缺失时报 `error_code="no_ffmpeg"` 中止；**单个转换失败的文件跳过不导入**（`convert_failed` 计数并在完成消息提示）
 - **静态版去重** (`dedup_static_against_animated`): Telegram 对同一动态贴纸缓存两份（512 webm 动画 + 320 webp 静态版），入库前用 PIL 识别动画 webp（`n_frames>1`），将每个静态 webp 与所有动画 webp 首帧做**归一化灰度差分**（白底合成 32×32，阈值 diff<0.02，实测匹配组 0.002-0.005 / 非匹配组 >0.1 间隔安全），内容一致的静态版跳过只保留动画版；无动画或 PIL 缺失时原样返回；`.webm` 文件（未转换时）不受影响。实测 127 静态中 45 个被判重跳过，0 误杀 0 漏跳，全量比较耗时 ~2s
 - **进度状态** (`_TG_STATE`): `idle` → `scanning` → `loading_key` → `decrypting` → `converting` → `importing` → `done`/`error`/`cancelled`，含 `error_code` 字段，前端 300ms 轮询 `get_tg_import_progress()`
 - **入库**: 解密到临时目录后调 `webui._do_import()` 入库，完成后自动清理临时文件

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+# v0.6.3
+
+## 修复
+
+- **微信导入 helper 二进制哈希配置** — `wechat_keyfinder` SHA-256 从占位符替换为真实值 `72f281c6...`，Windows 微信导入不再因未配置哈希而拒绝执行；下载 URL 指向 v0.6.3 release 资产
+- **Telegram WebM 转 WebP 循环播放** — ffmpeg 参数 `-loop 0` → `-loop 1`，转换后的动画 WebP 无限循环而非播放一次即停
+- **Telegram WebM 转换速度** — 无损编码（`-lossless 1 -quality 100`）实测 11-35s/个过慢导致"导入无反应"，改为有损 q80（`-lossless 0 -quality 80`），贴纸场景质量几乎无损，速度提升 3-7 倍
+
 # v0.6.2
 
 ## 变更

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """OhMyMeme - 轻量化跨平台表情包管理系统"""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 __app_name__ = "OhMyMeme"

--- a/src/tg_stickers.py
+++ b/src/tg_stickers.py
@@ -293,7 +293,7 @@ def _check_ffmpeg():
 
 
 def convert_webm_to_webp(webm_path, out_path):
-    """webm 转 animated webp: 无损(lossless 1), 保持宽高比, 最长边 512"""
+    """webm 转 animated webp: 有损(q80), 保持宽高比, 最长边 512"""
     try:
         cmd = [
             "ffmpeg",
@@ -303,11 +303,11 @@ def convert_webm_to_webp(webm_path, out_path):
             "-i",
             webm_path,
             "-loop",
-            "0",
-            "-lossless",
             "1",
+            "-lossless",
+            "0",
             "-quality",
-            "100",
+            "80",
             "-vf",
             "scale=512:512:force_original_aspect_ratio=decrease",
             "-an",

--- a/src/wechat_probe.py
+++ b/src/wechat_probe.py
@@ -33,13 +33,13 @@ logger = logging.getLogger(__name__)
 
 # 二进制完整性校验（发布时更新）
 _WECHAT_KEYFINDER_SHA256 = {
-    "Windows": "PLACEHOLDER_UPDATE_ON_RELEASE",
+    "Windows": "72f281c6b7638735b13c2c80f8de92034f49ce0e20d75feb6640c8c6e0dd4e31",
 }
 
 # 下载源（GitHub Releases）
 _WECHAT_KEYFINDER_URLS = {
     "Windows": (
-        "https://github.com/ZE514/OhMyMeme/releases/download/v0.6.0/"
+        "https://github.com/ZE514/OhMyMeme/releases/download/v0.6.3/"
         "wechat_keyfinder-windows-x64.exe"
     ),
 }


### PR DESCRIPTION
- wechat_probe: helper SHA-256 从占位符替换为真实值 72f281c6...， 微信导入不再被完整性校验拒绝执行；下载 URL 指向 v0.6.3 资产
- tg_stickers: WebM 转 WebP 参数 -loop 0 -> 1，动画无限循环
- tg_stickers: 无损编码改有损 q80，单文件 11-35s 降到 1.6-5.8s， 修复导入长时间无进度反馈；同步更新 AGENTS.md 描述

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Telegram WebM 转 WebP 现采用有损 Q80 编码，最长边限制为 512 像素且不会放大图片。
  * 转换流程保持失败跳过、删除原 WebM 及错误统计等行为。

* **问题修复**
  * 更新微信导入辅助工具的下载地址及完整性校验信息。

* **版本更新**
  * 应用版本升级至 v0.6.3。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->