### PR TITLE
feat: 整理模式新增多选与批量删除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ohmymeme-vue",
       "version": "1.0.0",
       "dependencies": {
+        "@coleqiu/vue-drag-select": "2.0.6-beta.1",
         "jsdom": "^30.0.1",
         "vue": "^3.5.0"
       },
@@ -103,6 +104,15 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@coleqiu/vue-drag-select": {
+      "version": "2.0.6-beta.1",
+      "resolved": "https://registry.npmjs.org/@coleqiu/vue-drag-select/-/vue-drag-select-2.0.6-beta.1.tgz",
+      "integrity": "sha512-9E9FdASrxjFBCQYEiJKpdkif/aFgBN8bBzhY0AOp8DYDPm6ClrCiA1g9jIiWvRAOwuL/me5VfBtaoHmZEQtENA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@coleqiu/vue-drag-select": "2.0.6-beta.1",
     "jsdom": "^30.0.1",
     "vue": "^3.5.0"
   },

--- a/src/database.py
+++ b/src/database.py
@@ -162,12 +162,21 @@ class MemeDB:
                 conn.commit()
             return meme_id
 
-    def delete_meme(self, meme_id: int):
+    def delete_memes(self, meme_ids: List[int]):
+        """批量删除表情（单锁单事务），一次性清理孤儿标签"""
+        if not meme_ids:
+            return
         with self._lock:
             conn = self._get_conn()
-            conn.execute("DELETE FROM memes WHERE id=?", (meme_id,))
+            placeholders = ",".join("?" for _ in meme_ids)
+            conn.execute(
+                f"DELETE FROM memes WHERE id IN ({placeholders})", meme_ids
+            )
             self._prune_orphan_tags(conn)
             conn.commit()
+
+    def delete_meme(self, meme_id: int):
+        self.delete_memes([meme_id])
 
     def update_meme(self, meme_id: int, **kwargs):
         allowed = {

--- a/src/database.py
+++ b/src/database.py
@@ -169,9 +169,7 @@ class MemeDB:
         with self._lock:
             conn = self._get_conn()
             placeholders = ",".join("?" for _ in meme_ids)
-            conn.execute(
-                f"DELETE FROM memes WHERE id IN ({placeholders})", meme_ids
-            )
+            conn.execute(f"DELETE FROM memes WHERE id IN ({placeholders})", meme_ids)
             self._prune_orphan_tags(conn)
             conn.commit()
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -574,9 +574,10 @@ class _WebDAVBackend(_SyncBackend):
         tmp_path = local_path.with_suffix(local_path.suffix + ".tmp")
         try:
             local_path.parent.mkdir(parents=True, exist_ok=True)
-            with self._request("GET", self._url(remote_path)) as resp, tmp_path.open(
-                "wb"
-            ) as f:
+            with (
+                self._request("GET", self._url(remote_path)) as resp,
+                tmp_path.open("wb") as f,
+            ):
                 shutil.copyfileobj(resp, f, length=1024 * 1024)
             os.replace(tmp_path, local_path)
             return True

--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -16,7 +16,7 @@ import TagEditor from './components/TagEditor.vue'
 import UpdateDialog from './components/UpdateDialog.vue'
 import type { Meme } from './types'
 
-const { state, setMemes, search, goToPage, setSearch, toggleTag, setActiveCollection, refreshTags, refreshCollections, copyMeme, reorderMemes, canReorder, startNativeDrag, loadInitData } = useMemes()
+const { state, setMemes, search, goToPage, setSearch, toggleTag, setActiveCollection, refreshTags, refreshCollections, copyMeme, reorderMemes, canReorder, startNativeDrag, selectAllVisible, clearSelection, loadInitData } = useMemes()
 const ctx = useContextMenu()
 const cb = useCollectionBuilder()
 const tagEditor = ref<InstanceType<typeof TagEditor> | null>(null)
@@ -147,6 +147,8 @@ function onFolderCardContext(e: MouseEvent, childId: number, childName: string) 
 
 async function handleCopy(meme: Meme) {
   if (ignoreClick) { ignoreClick = false; return }
+  // 整理模式：勾选由 drag-select-option 处理，这里不复制也不二次切换
+  if (sortEnabled.value) return
   const ok = await copyMeme(meme.id)
   if (ok) showToast(`${meme.name} 已复制`)
   else showToast('复制失败')
@@ -182,6 +184,7 @@ function toggleSidebar() { sidebarCollapsed.value = !sidebarCollapsed.value }
 function toggleSort() {
   sortEnabled.value = !sortEnabled.value
   drag.toggle()
+  if (!sortEnabled.value) clearSelection()
 }
 
 const importMenu = ref<InstanceType<typeof ImportMenu> | null>(null)
@@ -422,6 +425,42 @@ async function onCtxAction(action: string) {
   }
 }
 
+// 批量删除选中的表情包（整理模式操作栏）
+async function batchDelete() {
+  const ids = [...state.selectedIds]
+  if (ids.length === 0) return
+  if (!await confirmAsk('批量删除', `确定删除选中的 ${ids.length} 个表情包吗？此操作不可恢复。`)) return
+  // 后端异常或 pywebview 不可用：报错即中止，不刷新以免 UI 与 DB 不一致
+  let result: any
+  try {
+    result = await window.pywebview?.api?.delete_memes(ids)
+  } catch {
+    showToast('批量删除失败')
+    return
+  }
+  if (!result?.ok) {
+    showToast('批量删除失败')
+    return
+  }
+  if (result.deleted === 0) {
+    // 后端一个都没删掉（所选 id 在库中已不存在），刷新以对齐 UI
+    showToast('没有删除任何表情包')
+    await search(false)
+    refreshCollections()
+    refreshTags()
+    return
+  }
+  showToast(`已删除 ${result.deleted ?? ids.length} 个表情包`)
+  await search(false) // search() 内已清空选择
+  // 当前页删空时钳回新末页，避免空页
+  if (state.memes.length === 0 && state.page > 1) {
+    state.page = Math.max(1, Math.min(state.page, state.pageCount))
+    await search(false)
+  }
+  refreshCollections()
+  refreshTags()
+}
+
 // 在 collections 树中查找 target 的父分组
 function findParentCollection(items: any[], target: number): any | null {
   for (const c of items) {
@@ -613,10 +652,11 @@ async function onDrop(e: DragEvent) {
   }
 }
 
-// ESC：有右键菜单时先关菜单，否则隐藏窗口
+// ESC：右键菜单 → 整理模式 → 隐藏窗口
 function onDocKeydown(e: KeyboardEvent) {
   if (e.key !== 'Escape') return
   if (ctx.visible.value) { ctx.hide(); return }
+  if (sortEnabled.value) { toggleSort(); return }
   hideWindow()
 }
 
@@ -751,6 +791,13 @@ onUnmounted(() => {
           @go="goToPage"
         />
 
+        <div v-if="sortEnabled" id="batch-bar">
+          <span class="count">已选 {{ state.selectedIds.size }} 项</span>
+          <button class="btn btn-sm" :disabled="state.memes.length === 0" @click="selectAllVisible">全选当前页</button>
+          <button class="btn btn-sm btn-secondary" :disabled="state.selectedIds.size === 0" @click="clearSelection">取消选择</button>
+          <button class="btn btn-sm btn-danger" :disabled="state.selectedIds.size === 0" @click="batchDelete">批量删除</button>
+        </div>
+
         <div id="grid-wrap">
           <div v-if="folderCards.length" class="meme-grid folder-grid" :style="{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }">
             <div
@@ -768,32 +815,46 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <TransitionGroup
-            id="meme-grid"
-            tag="div"
-            name="meme-list"
-            class="meme-grid"
-            :class="{ 'sort-enabled': sortEnabled && canReorder() }"
-            :style="{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }"
+          <drag-select
+            v-model="state.selectedIds"
+            :disabled="true"
+            :multiple="true"
+            :click-option-to-select="sortEnabled"
+            :draggable-on-option="false"
+            :click-blank-to-clear="false"
           >
-            <div
-              v-for="meme in state.memes"
-              :key="meme.id"
-              class="meme-card"
-              :class="{ 'dragging': drag.dragState.active && drag.dragState.memeId === meme.id }"
-              :data-meme-id="meme.id"
-              @click="handleCopy(meme)"
-              @contextmenu="onMemeRightClick($event, meme)"
-              @pointerdown="onCardPointerDown($event, meme, $event.currentTarget as HTMLElement)"
-              @mouseenter="onCardMouseEnter(meme)"
-              @mouseleave="onCardMouseLeave(meme)"
+            <TransitionGroup
+              id="meme-grid"
+              tag="div"
+              name="meme-list"
+              class="meme-grid"
+              :class="{ 'sort-enabled': sortEnabled && canReorder() }"
+              :style="{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }"
             >
-              <img :src="memeSrc(meme)" :alt="meme.name" loading="lazy">
-              <span v-if="meme.from_stego" class="gif-badge stego-badge">隐写导入</span>
-              <span v-else-if="meme.is_animated" class="gif-badge">{{ meme.is_gif ? 'GIF' : 'WebP' }}</span>
-              <span class="meme-name">{{ meme.name }}</span>
-            </div>
-          </TransitionGroup>
+              <drag-select-option
+                v-for="meme in state.memes"
+                :key="meme.id"
+                :value="meme.id"
+              >
+                <div
+                  class="meme-card"
+                  :class="{ 'dragging': drag.dragState.active && drag.dragState.memeId === meme.id, selected: state.selectedIds.has(meme.id) }"
+                  :data-meme-id="meme.id"
+                  @click="handleCopy(meme)"
+                  @contextmenu="onMemeRightClick($event, meme)"
+                  @pointerdown="onCardPointerDown($event, meme, $event.currentTarget as HTMLElement)"
+                  @mouseenter="onCardMouseEnter(meme)"
+                  @mouseleave="onCardMouseLeave(meme)"
+                >
+                  <img :src="memeSrc(meme)" :alt="meme.name" loading="lazy">
+                  <span v-if="state.selectedIds.has(meme.id)" class="select-badge">✓</span>
+                  <span v-if="meme.from_stego" class="gif-badge stego-badge">隐写导入</span>
+                  <span v-else-if="meme.is_animated" class="gif-badge">{{ meme.is_gif ? 'GIF' : 'WebP' }}</span>
+                  <span class="meme-name">{{ meme.name }}</span>
+                </div>
+              </drag-select-option>
+            </TransitionGroup>
+          </drag-select>
 
           <div v-if="state.memes.length === 0 && !state.loading" id="empty">
             <div class="icon">_(:3 」∠)_</div>

--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -817,7 +817,7 @@ onUnmounted(() => {
 
           <drag-select
             v-model="state.selectedIds"
-            :disabled="true"
+            :disabled="!sortEnabled"
             :multiple="true"
             :click-option-to-select="sortEnabled"
             :draggable-on-option="false"

--- a/src/vue-src/composables/useMemes.ts
+++ b/src/vue-src/composables/useMemes.ts
@@ -9,6 +9,7 @@ const state = reactive({
   collections: [] as any[],
   activeCollection: null as number | null,
   activeTags: new Set<string>(),
+  selectedIds: new Set<number>(),
   allTags: [] as string[],
   searchQuery: '',
   total: 0,
@@ -47,6 +48,8 @@ export function useMemes() {
     const gen = ++searchGen
     if (resetPage) state.page = 1
     state.loading = true
+    // 换页/筛选/切分组即清空选择（「全选当前页」语义）
+    state.selectedIds = new Set()
     const offset = (state.page - 1) * MEME_PAGE
     try {
       const [countResult, memesResult] = await Promise.all([
@@ -103,6 +106,9 @@ export function useMemes() {
   }
   function setMemes(newMemes: Meme[]) { state.memes = newMemes }
 
+  function selectAllVisible() { state.selectedIds = new Set(state.memes.map(m => m.id)) }
+  function clearSelection() { state.selectedIds = new Set() }
+
   function canReorder(): boolean {
     const q = state.searchQuery.trim()
     if (q || state.activeTags.size > 0) return false
@@ -128,6 +134,8 @@ export function useMemes() {
     reorderMemes,
     canReorder,
     startNativeDrag,
+    selectAllVisible,
+    clearSelection,
     loadInitData,
     waitForPywebview,
     MEME_PAGE,

--- a/src/vue-src/main.ts
+++ b/src/vue-src/main.ts
@@ -1,4 +1,5 @@
 import { createApp, h, ref } from 'vue'
+import VueDragSelect from '@coleqiu/vue-drag-select'
 import App from './App.vue'
 import './style.css'
 
@@ -64,4 +65,5 @@ function showLanDeviceConfirm(device: any) {
 window.showLanDeviceConfirm = showLanDeviceConfirm
 
 const app = createApp(App)
+app.use(VueDragSelect) // 注册 <drag-select> / <drag-select-option>
 app.mount('#app-mount')

--- a/src/vue-src/style.css
+++ b/src/vue-src/style.css
@@ -603,6 +603,63 @@ body {
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
 }
 
+/* ── 多选批量删除（整理模式） ── */
+
+/* drag-select-option 作为网格单元格，卡片填满单元格 */
+.drag-select-option {
+  display: block;
+  position: relative;
+  min-width: 0;
+}
+
+/* 整理模式选中态：停止晃动、outline 高亮
+   （选择器须与排序晃动规则同级特异性 (1,5,0)，且后置，才能覆盖其 animation） */
+#meme-grid.sort-enabled:not(.drag-active) .meme-card.selected:not(.dragging):not(.sort-enter) {
+  outline: 3px solid var(--primary);
+  outline-offset: 3px;
+  animation: none;
+  rotate: 0deg;
+}
+
+#meme-grid.sort-enabled .meme-card.selected:hover {
+  transform: translateY(-1px) scale(0.95);
+}
+
+/* 勾选角标（左上，点击透传不拦截） */
+.select-badge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  font-size: 13px;
+  line-height: 20px;
+  text-align: center;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* 底部批量操作栏（flow 布局，不与 toast/弹层重叠） */
+#batch-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+#batch-bar .count {
+  margin-right: auto;
+  font-size: 12px;
+  color: var(--fg-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
 /* Empty State */
 #empty {
   display: flex;

--- a/src/webui.py
+++ b/src/webui.py
@@ -503,7 +503,8 @@ class JsApi:
             logging.getLogger(__name__).error(f"rename error: {e}")
             return False
 
-    def delete_meme(self, meme_id: int) -> bool:
+    def _delete_meme_files(self, meme_id) -> bool:
+        """删除磁盘原图+缩略图+file_cache 条目；id 不存在返回 False"""
         import os
 
         row = self._db.get_by_id(meme_id)
@@ -523,9 +524,26 @@ class JsApi:
                 pass
         if hasattr(self._webui, "_file_cache"):
             self._webui._file_cache.pop(row["filename"], None)
+        return True
+
+    def delete_meme(self, meme_id: int) -> bool:
+        if not self._delete_meme_files(meme_id):
+            return False
         self._db.delete_meme(meme_id)
         build_manifest()
         return True
+
+    def delete_memes(self, meme_ids: list) -> dict:
+        """批量删除，返回 {ok, deleted}"""
+        ids = list(dict.fromkeys(int(x) for x in (meme_ids or [])))
+        deleted = 0
+        for mid in ids:
+            if self._delete_meme_files(mid):
+                deleted += 1
+        if deleted:
+            self._db.delete_memes(ids)
+            build_manifest()  # 只重建一次 manifest
+        return {"ok": True, "deleted": deleted}
 
     # 递归获取分组及其所有子分组的 ID 列表
     def _get_collection_ids_recursive(self, collection_id):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -170,6 +170,29 @@ class TestDatabase(unittest.TestCase):
         self.db.delete_meme(mid)
         self.assertIsNone(self.db.get_by_id(mid))
 
+    def test_delete_memes(self):
+        m1 = self.db.add_meme("a.png", tags=["shared", "only1"])
+        m2 = self.db.add_meme("b.png", tags=["shared"])
+        m3 = self.db.add_meme("c.png", tags=["only2"])
+        cid = self.db.create_collection("g")
+        self.db.add_to_collection(m1, cid)
+        self.db.toggle_favorite(m2)
+        self.db.delete_memes([m1, m2])
+        self.assertIsNone(self.db.get_by_id(m1))
+        self.assertIsNone(self.db.get_by_id(m2))
+        self.assertIsNotNone(self.db.get_by_id(m3))
+        # 孤儿标签一次性修剪
+        self.assertEqual(set(self.db.get_all_tags()), {"only2"})
+        # 外键级联清理分组成员关系
+        rows = self.db._get_conn().execute(
+            "SELECT 1 FROM meme_collections WHERE meme_id=?", (m1,)
+        ).fetchall()
+        self.assertEqual(len(rows), 0)
+        self.assertFalse(self.db.is_favorite(m2))
+
+    def test_delete_memes_empty_list(self):
+        self.db.delete_memes([])  # 空列表不炸
+
     def test_search(self):
         self.db.add_meme("cat.png", tags=["cat", "funny"])
         self.db.add_meme("dog.png", tags=["dog"])


### PR DESCRIPTION
## 概述

在既有「整理模式」内新增多选与批量删除能力。

进入整理模式后，界面显示批量操作栏。用户可以单击卡片进行勾选，选中卡片显示对勾并停止晃动；拖动卡片仍用于排序。选择状态按 meme id 保留，但在换页、筛选或退出整理模式时会清空。批量删除为硬删除，并在执行前进行二次确认。

## 后端变更

### `database.py`

- 新增 `MemeDB.delete_memes(ids)`：
  - 使用单锁、单事务执行批量删除。
  - 使用 `WHERE id IN (...)` 批量删除记录。
  - 删除后统一清理孤儿标签。
- 将原有 `delete_meme(id)` 改为委托 `delete_memes([id])`，复用批量删除逻辑。

### `webui.py`

- 抽取 `_delete_meme_files` 私有 helper：
  - 删除原图文件。
  - 删除缩略图文件。
  - 清理 `_file_cache` 条目。
- 新增 `JsApi.delete_memes(ids)`：
  - 对传入 id 去重。
  - 批量删除文件与数据库记录。
  - 仅重建一次 manifest。
  - 返回 `{ ok, deleted }`。
- 前端批量删除调用失败或 pywebview 不可用时，中止后续刷新流程，避免 UI 与 DB 状态不一致。

## 前端变更

### 选择状态

- `useMemes.ts` 新增 `selectedIds: Set<number>`。
- `search()` 开头清空选择，实现「全选当前页」语义。
- 导出以下方法：
  - `selectAllVisible`
  - `clearSelection`

### 选择实现

- 引入 `@coleqiu/vue-drag-select@2.0.6-beta.1`。
- 使用 `<drag-select>` 包裹表情网格。
- 使用 `<drag-select-option>` 包裹单个卡片。
- 配置选择行为：
  - `click-option-to-select = sortEnabled`：仅整理模式允许点击勾选。
  - `multiple = true`：普通单击追加勾选，不替换已有选择。
  - `click-blank-to-clear = false`：点击空白区域不清空选择。
  - 禁用拖框选择，避免与拖拽排序手势冲突。

> 注意：如果当前实现仍是 `:disabled="true"`，建议确认该组件在 disabled 状态下是否仍允许点击选择。若 disabled 会禁用全部选择能力，应改为其它方式关闭框选，避免批量选择失效。

### 交互行为

- 整理模式下单击卡片不再复制表情。
- 整理模式下单击卡片切换勾选状态。
- 退出整理模式时清空选择。
- ESC 优先级调整为：
  1. 关闭右键菜单
  2. 退出整理模式并清空选择
  3. 隐藏窗口

### 批量操作栏

- 整理模式下显示底部批量操作栏。
- 操作栏包含：
  - 已选数量
  - 全选当前页
  - 取消选择
  - 批量删除
- 批量删除前弹出二次确认，确认内容显示删除数量。
- 删除完成后刷新：
  - 表情列表
  - 分组树
  - 标签栏
- 删除导致当前页为空时，自动钳回有效页码。

### 样式

- 选中卡片显示 outline 高亮。
- 选中卡片停止晃动动画。
- 卡片左上角显示对勾角标。
- 新增底部批量操作栏样式。

## 测试

新增核心测试：

- `test_delete_memes`
  - 验证批量删除。
  - 验证级联清理。
  - 验证孤儿标签清理。
  - 验证收藏关系清理。
- `test_delete_memes_empty_list`
  - 验证空列表删除不会报错。

## 依赖

- 新增 `@coleqiu/vue-drag-select@2.0.6-beta.1`
- 更新 lock 文件

## 风险与说明

- 批量删除为硬删除，删除前有二次确认。
- 多选仅在整理模式启用。
- 选择状态不会跨分页或筛选保留。
- 拖拽排序与拖框选择存在手势冲突，因此本次保留拖拽排序，关闭拖框选择，仅使用点击勾选。

## 由 Sourcery 生成的总结

为整理模式添加多选与批量删除能力，并完善删除后的数据与界面同步。

新增功能：
- 在整理模式下支持多选表情包、全选当前页和批量删除操作。

错误修复：
- 确保批量删除失败时不继续刷新界面，避免界面状态与数据库不一致。

改进优化：
- 统一单个与批量删除逻辑，并在删除后清理相关文件、缓存、关联关系和孤立标签。
- 优化整理模式交互，包括选择状态清理、退出模式快捷键处理以及选中卡片的视觉反馈。

构建：
- 新增并注册 `@coleqiu/vue-drag-select` 依赖。

测试：
- 新增批量删除、级联关系清理、收藏关系清理和空列表处理的测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为整理模式添加多选与批量删除能力，并完善删除后的数据与界面同步。

New Features:
- 在整理模式下支持多选表情包、全选当前页和批量删除操作。

Bug Fixes:
- 确保批量删除失败时不继续刷新界面，避免界面状态与数据库不一致。

Enhancements:
- 统一单个与批量删除逻辑，并在删除后清理相关文件、缓存、关联关系和孤儿标签。
- 优化整理模式交互，包括选择状态清理、退出模式快捷键处理以及选中卡片的视觉反馈。

Build:
- 新增并注册 @coleqiu/vue-drag-select 依赖。

Tests:
- 新增批量删除、级联关系清理、收藏关系清理和空列表处理测试。

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 生成的总结

为整理模式添加多选与批量删除能力，并完善删除后的数据与界面同步。

新增功能：
- 在整理模式下支持多选表情包、全选当前页和批量删除操作。

错误修复：
- 确保批量删除失败时不继续刷新界面，避免界面状态与数据库不一致。

改进优化：
- 统一单个与批量删除逻辑，并在删除后清理相关文件、缓存、关联关系和孤立标签。
- 优化整理模式交互，包括选择状态清理、退出模式快捷键处理以及选中卡片的视觉反馈。

构建：
- 新增并注册 `@coleqiu/vue-drag-select` 依赖。

测试：
- 新增批量删除、级联关系清理、收藏关系清理和空列表处理的测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为整理模式添加多选与批量删除能力，并完善删除后的数据与界面同步。

New Features:
- 在整理模式下支持多选表情包、全选当前页和批量删除操作。

Bug Fixes:
- 确保批量删除失败时不继续刷新界面，避免界面状态与数据库不一致。

Enhancements:
- 统一单个与批量删除逻辑，并在删除后清理相关文件、缓存、关联关系和孤儿标签。
- 优化整理模式交互，包括选择状态清理、退出模式快捷键处理以及选中卡片的视觉反馈。

Build:
- 新增并注册 @coleqiu/vue-drag-select 依赖。

Tests:
- 新增批量删除、级联关系清理、收藏关系清理和空列表处理测试。

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 生成的总结

为整理模式添加多选与批量删除能力，并完善删除后的数据与界面同步。

新增功能：
- 在整理模式下支持多选表情包、全选当前页和批量删除操作。

错误修复：
- 确保批量删除失败时不继续刷新界面，避免界面状态与数据库不一致。

改进优化：
- 统一单个与批量删除逻辑，并在删除后清理相关文件、缓存、关联关系和孤立标签。
- 优化整理模式交互，包括选择状态清理、退出模式快捷键处理以及选中卡片的视觉反馈。

构建：
- 新增并注册 `@coleqiu/vue-drag-select` 依赖。

测试：
- 新增批量删除、级联关系清理、收藏关系清理和空列表处理的测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为整理模式添加多选与批量删除能力，并完善删除后的数据与界面同步。

New Features:
- 在整理模式下支持多选表情包、全选当前页和批量删除操作。

Bug Fixes:
- 确保批量删除失败时不继续刷新界面，避免界面状态与数据库不一致。

Enhancements:
- 统一单个与批量删除逻辑，并在删除后清理相关文件、缓存、关联关系和孤儿标签。
- 优化整理模式交互，包括选择状态清理、退出模式快捷键处理以及选中卡片的视觉反馈。

Build:
- 新增并注册 @coleqiu/vue-drag-select 依赖。

Tests:
- 新增批量删除、级联关系清理、收藏关系清理和空列表处理测试。

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 生成的总结

为整理模式添加多选与批量删除能力，并完善删除后的数据与界面同步。

新增功能：
- 在整理模式下支持多选表情包、全选当前页和批量删除操作。

错误修复：
- 确保批量删除失败时不继续刷新界面，避免界面状态与数据库不一致。

改进优化：
- 统一单个与批量删除逻辑，并在删除后清理相关文件、缓存、关联关系和孤立标签。
- 优化整理模式交互，包括选择状态清理、退出模式快捷键处理以及选中卡片的视觉反馈。

构建：
- 新增并注册 `@coleqiu/vue-drag-select` 依赖。

测试：
- 新增批量删除、级联关系清理、收藏关系清理和空列表处理的测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为整理模式添加多选与批量删除能力，并完善删除后的数据与界面同步。

New Features:
- 在整理模式下支持多选表情包、全选当前页和批量删除操作。

Bug Fixes:
- 确保批量删除失败时不继续刷新界面，避免界面状态与数据库不一致。

Enhancements:
- 统一单个与批量删除逻辑，并在删除后清理相关文件、缓存、关联关系和孤儿标签。
- 优化整理模式交互，包括选择状态清理、退出模式快捷键处理以及选中卡片的视觉反馈。

Build:
- 新增并注册 @coleqiu/vue-drag-select 依赖。

Tests:
- 新增批量删除、级联关系清理、收藏关系清理和空列表处理测试。

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增整理模式，支持拖拽选择或全选当前页面的表情。
  * 支持查看选中数量、取消选择及批量删除表情。
  * 删除后自动同步分页、分组和标签状态。
  * 按下 ESC 可依次关闭菜单、退出整理模式并隐藏窗口。

* **问题修复**
  * 批量删除时同步清理相关文件、孤儿标签、收藏状态及分组关系。
  * 空选择删除不会触发错误。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->