### PR TITLE
fix(import): 补全导入错误日志与用户提示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ Thumbs.db
 # ADB 自动下载
 .adb/
 
+# 本地契约校验脚本（不上传，个人使用）
+scripts/check_contract.py
+
 # 打包输出
 *.exe
 *.AppImage

--- a/src/adb_util.py
+++ b/src/adb_util.py
@@ -394,6 +394,7 @@ def _find_qq_favorite_dir(adb_path):
 
 
 def _qq_worker():
+    """后台执行 QQ 表情包导入：检测/下载 ADB → 连接设备 → 拉取缓存 → 打包 ZIP"""
     _update_qq(status="downloading_adb", progress=0, message="检查 ADB...", error="")
     adb_path = detect_adb()
     if _check_cancel():

--- a/src/adb_util.py
+++ b/src/adb_util.py
@@ -251,6 +251,7 @@ def _download_with_progress():
     """下载 ADB 并更新 _QQ_STATE 进度"""
     url = _adb_download_url()
     if not url:
+        logger.error("adb download: 不支持的平台")
         _update_qq(status="error", error="unsupported platform")
         return False
     adb_dir = _get_adb_dir()
@@ -287,9 +288,11 @@ def _download_with_progress():
             _ADB_STATE["done"] = True
             return str(exe_path)
         _update_qq(status="error", error="解压后未找到 adb")
+        logger.error("adb download: 解压后未找到 adb")
         return False
     except Exception as e:
         _update_qq(status="error", error=str(e))
+        logger.error("adb download: 下载/解压失败: %s", e)
         if zip_path.exists():
             try:
                 zip_path.unlink()
@@ -404,6 +407,7 @@ def _qq_worker():
                     status="error",
                     error="ADB 下载失败，请手动下载并放入 .adb 文件夹",
                 )
+                logger.error("qq import: ADB 下载失败")
             return
     if _check_cancel():
         return
@@ -412,6 +416,7 @@ def _qq_worker():
         _run_adb(adb_path, ["start-server"], timeout=10)
     except Exception as e:
         _update_qq(status="error", error="ADB 启动失败: %s" % e)
+        logger.error("qq import: ADB 启动失败: %s", e)
         return
     if _check_cancel():
         return
@@ -438,6 +443,7 @@ def _qq_worker():
         _update_qq(
             status="error", error="未检测到设备，请确认手机已连接并开启 USB 调试"
         )
+        logger.error("qq import: 未检测到 ADB 设备")
         return
     if _check_cancel():
         return
@@ -447,10 +453,12 @@ def _qq_worker():
         remote = _find_qq_favorite_dir(adb_path)
     except subprocess.TimeoutExpired:
         _update_qq(status="error", error="检测存储目录超时，请检查 ADB 连接")
+        logger.error("qq import: 检测存储目录超时")
         shutil.rmtree(tmp_dir, ignore_errors=True)
         return
     except Exception as e:
         _update_qq(status="error", error="检测存储目录失败: %s" % e)
+        logger.error("qq import: 检测存储目录失败: %s", e)
         shutil.rmtree(tmp_dir, ignore_errors=True)
         return
     if _check_cancel():
@@ -462,6 +470,7 @@ def _qq_worker():
             error="未找到 QQ_Favorite 目录，请确认手机已安装 QQ"
             "（含外置存储卡时检查 TF 卡）",
         )
+        logger.error("qq import: 未找到 QQ_Favorite 目录")
         shutil.rmtree(tmp_dir, ignore_errors=True)
         return
     pull_ok = False
@@ -473,10 +482,12 @@ def _qq_worker():
         pull_ok = False
     except Exception as e:
         _update_qq(status="error", error="拉取文件失败: %s" % e)
+        logger.error("qq import: 拉取文件失败: %s", e)
         shutil.rmtree(tmp_dir, ignore_errors=True)
         return
     if not pull_ok:
         _update_qq(status="error", error="拉取文件失败，请检查 USB 连接")
+        logger.error("qq import: 拉取文件失败（USB 连接）")
         shutil.rmtree(tmp_dir, ignore_errors=True)
         return
     if _check_cancel():
@@ -511,6 +522,7 @@ def _qq_worker():
                     zf.write(f, f.name)
     except Exception as e:
         _update_qq(status="error", error="打包失败: %s" % e)
+        logger.error("qq import: 打包 ZIP 失败: %s", e)
         shutil.rmtree(tmp_dir, ignore_errors=True)
         return
     shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/src/douyin.py
+++ b/src/douyin.py
@@ -81,6 +81,7 @@ def _reset_state():
         done=0,
         imported=0,
         rejected=0,
+        download_failed=0,
     )
 
 
@@ -358,7 +359,13 @@ def start_douyin_import(webui, cookie: str) -> bool:
                 except Exception as e:
                     logger.warning("download %s failed: %s", item["id"], e)
                     download_failed += 1
-                    _update_dy(done=i + 1)
+                    done = i + 1
+                    _update_dy(
+                        done=done,
+                        progress=int(done * 100 / total),
+                        message=f"下载中 {done}/{total}",
+                        download_failed=download_failed,
+                    )
 
             if _check_cancel():
                 _update_dy(status="cancelled", message="已取消")
@@ -384,8 +391,14 @@ def start_douyin_import(webui, cookie: str) -> bool:
                     download_failed=download_failed,
                 )
             else:
+                msg = "下载完成（无有效数据）"
+                if download_failed:
+                    msg += f"，{download_failed} 个下载失败"
                 _update_dy(
-                    status="done", progress=100, message="下载完成（无有效数据）"
+                    status="done",
+                    progress=100,
+                    message=msg,
+                    download_failed=download_failed,
                 )
 
         except Exception as e:

--- a/src/douyin.py
+++ b/src/douyin.py
@@ -297,6 +297,7 @@ def start_douyin_import(webui, cookie: str) -> bool:
         global _DOUYIN_CANCEL
         tmp_dir = tempfile.mkdtemp(prefix="dy_")
         downloaded = []
+        download_failed = 0
 
         try:
             _update_dy(message="初始化 Session...")
@@ -304,6 +305,7 @@ def start_douyin_import(webui, cookie: str) -> bool:
 
             _update_dy(message="检查登录状态...")
             if not _check_login(session):
+                logger.error("douyin import: 登录失败（Cookie 无效或已过期）")
                 _update_dy(
                     status="error",
                     error="登录失败：Cookie 无效或已过期",
@@ -319,6 +321,7 @@ def start_douyin_import(webui, cookie: str) -> bool:
                 return
 
             if stickers is None:
+                logger.error("douyin import: 接口返回 403，签名验证失败")
                 _update_dy(
                     status="error",
                     error="接口返回 403：签名验证失败",
@@ -327,6 +330,7 @@ def start_douyin_import(webui, cookie: str) -> bool:
                 return
 
             if not stickers:
+                logger.error("douyin import: 未获取到任何表情包")
                 _update_dy(
                     status="error",
                     error="未获取到任何表情包",
@@ -353,6 +357,7 @@ def start_douyin_import(webui, cookie: str) -> bool:
                     )
                 except Exception as e:
                     logger.warning("download %s failed: %s", item["id"], e)
+                    download_failed += 1
                     _update_dy(done=i + 1)
 
             if _check_cancel():
@@ -365,12 +370,18 @@ def start_douyin_import(webui, cookie: str) -> bool:
                 result = webui._do_import(downloaded)
                 imported = len(result.get("ids", []))
                 rejected = result.get("rejected", 0)
+                msg = f"导入完成：{imported} 个成功"
+                if rejected:
+                    msg += f"，{rejected} 个跳过"
+                if download_failed:
+                    msg += f"，{download_failed} 个下载失败"
                 _update_dy(
                     status="done",
                     progress=100,
-                    message=f"导入完成：{imported} 个成功，{rejected} 个跳过",
+                    message=msg,
                     imported=imported,
                     rejected=rejected,
+                    download_failed=download_failed,
                 )
             else:
                 _update_dy(

--- a/src/tg_stickers.py
+++ b/src/tg_stickers.py
@@ -401,6 +401,7 @@ def start_tg_import(webui, tdata_path=None, passcode="", convert_webm=True):
             "loading_key",
             "decrypting",
             "converting",
+            "deduping",
             "importing",
         ):
             return False
@@ -624,7 +625,6 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
         if _check_cancel():
             _update_tg(status="cancelled", message="已取消")
             return
-        # 分批入库，每批更新进度，避免大批量导入时进度条长时间不动
         total = len(decrypted_paths)
         imported_ids = []
         rejected = 0

--- a/src/tg_stickers.py
+++ b/src/tg_stickers.py
@@ -424,6 +424,7 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
         if tdata_path:
             tdata = tdata_path
             if not is_valid_tdata(tdata):
+                logger.error("tg import: 无效 tdata 目录: %s", tdata)
                 _update_tg(
                     status="error",
                     error_code="invalid_tdata",
@@ -436,6 +437,7 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
         else:
             tdata = find_tdata_path()
             if not tdata:
+                logger.error("tg import: 未检测到 tdata 目录")
                 _update_tg(
                     status="error",
                     error_code="no_tdata",
@@ -453,6 +455,7 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
         if not os.path.exists(key_path):
             key_path = os.path.join(tdata, "key_data")
         if not os.path.exists(key_path):
+            logger.error("tg import: 未找到 key_datas 文件: %s", key_path)
             _update_tg(
                 status="error",
                 error_code="invalid_tdata",
@@ -462,6 +465,7 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
         try:
             local_key = read_local_key(key_path, passcode)
         except Exception as e:
+            logger.error("tg import: 密钥加载失败: %s", e)
             _update_tg(
                 status="error",
                 error_code="bad_key",
@@ -477,6 +481,7 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
             if os.path.isdir(p):
                 cache_dirs.append(p)
         if not cache_dirs:
+            logger.error("tg import: 未找到缓存目录: %s", tdata)
             _update_tg(status="error", error_code="no_cache", error="未找到缓存目录")
             return
         all_files = []
@@ -538,6 +543,7 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
         if convert_webm:
             webm_count = sum(1 for p in decrypted_paths if p.endswith(".webm"))
             if webm_count and not _check_ffmpeg():
+                logger.error("tg import: 检测到 WebM 但未安装 ffmpeg")
                 _update_tg(
                     status="error",
                     error_code="no_ffmpeg",
@@ -583,6 +589,13 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
             _update_tg(status="converting", message="转换完成")
         skipped_static = 0
         if decrypted_paths:
+            _update_tg(
+                status="deduping",
+                message="正在去重动态表情的静态版本...",
+                progress=0,
+                done=0,
+                total=len(decrypted_paths),
+            )
             decrypted_paths, skipped_static = dedup_static_against_animated(
                 decrypted_paths
             )
@@ -611,9 +624,26 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
         if _check_cancel():
             _update_tg(status="cancelled", message="已取消")
             return
-        result = webui._do_import(decrypted_paths)
-        imported = len(result.get("ids", []))
-        rejected = result.get("rejected", 0)
+        # 分批入库，每批更新进度，避免大批量导入时进度条长时间不动
+        total = len(decrypted_paths)
+        imported_ids = []
+        rejected = 0
+        batch = 20
+        for i in range(0, total, batch):
+            if _check_cancel():
+                _update_tg(status="cancelled", message="已取消")
+                return
+            chunk = decrypted_paths[i : i + batch]
+            r = webui._do_import(chunk)
+            imported_ids.extend(r.get("ids", []))
+            rejected += r.get("rejected", 0)
+            _update_tg(
+                status="importing",
+                message=f"正在导入: {min(i + batch, total)}/{total}",
+                progress=int(min(i + batch, total) / total * 100),
+                done=min(i + batch, total),
+            )
+        imported = len(imported_ids)
         msg = f"导入完成，共 {imported} 个表情"
         if convert_failed:
             msg += f"（{convert_failed} 个 WebM 转换失败已跳过）"
@@ -623,7 +653,7 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
             status="done",
             message=msg,
             progress=100,
-            done=len(decrypted_paths),
+            done=total,
             imported=imported,
             rejected=rejected,
             convert_failed=convert_failed,

--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -174,9 +174,9 @@ function debounceSearch() {
   searchTimer = setTimeout(() => search(), 300)
 }
 
-function openSettings() {
+async function openSettings() {
   try {
-    const ok = window.pywebview?.api?.open_settings()
+    const ok = await window.pywebview?.api?.open_settings()
     if (!ok) showToast('无法打开设置窗口')
   } catch (_) {
     showToast('无法打开设置窗口')
@@ -650,18 +650,24 @@ async function onDrop(e: DragEvent) {
     }
   }
   if (file) {
+    let b64: string
     try {
-      const b64 = await new Promise<string>((resolve, reject) => {
+      b64 = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader()
         reader.onload = () => resolve((reader.result as string).split(',')[1])
         reader.onerror = () => reject(reader.error)
         reader.readAsDataURL(file!)
       })
+    } catch (_) {
+      showToast('导入失败：无法读取文件')
+      return
+    }
+    try {
       const res = await fetch('/api/upload/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files: [{ name: file.name, data: b64 }] }) })
       if (res.ok) { showToast('导入成功'); search(); refreshCollections() }
       else { showToast('导入失败：服务器返回错误') }
     } catch (_) {
-      showToast('导入失败：无法读取文件')
+      showToast('导入失败：网络或服务异常')
     }
     return
   }

--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -176,8 +176,11 @@ function debounceSearch() {
 
 function openSettings() {
   try {
-    window.pywebview?.api?.open_settings()
-  } catch (_) {}
+    const ok = window.pywebview?.api?.open_settings()
+    if (!ok) showToast('无法打开设置窗口')
+  } catch (_) {
+    showToast('无法打开设置窗口')
+  }
 }
 function toggleSidebar() { sidebarCollapsed.value = !sidebarCollapsed.value }
 
@@ -636,7 +639,15 @@ async function onDrop(e: DragEvent) {
     } catch (_) {}
   }
   if (uri) {
-    try { const r = await window.pywebview?.api?.download_original_image(uri); if (r?.ok) { showToast('导入成功'); search(); refreshCollections(); return } } catch (_) {}
+    try {
+      const r = await window.pywebview?.api?.download_original_image(uri)
+      if (r?.ok) { showToast('导入成功'); search(); refreshCollections(); return }
+      showToast(r?.error || '导入失败')
+      return
+    } catch (_) {
+      showToast('导入失败')
+      return
+    }
   }
   if (file) {
     try {
@@ -648,8 +659,13 @@ async function onDrop(e: DragEvent) {
       })
       const res = await fetch('/api/upload/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files: [{ name: file.name, data: b64 }] }) })
       if (res.ok) { showToast('导入成功'); search(); refreshCollections() }
-    } catch (_) {}
+      else { showToast('导入失败：服务器返回错误') }
+    } catch (_) {
+      showToast('导入失败：无法读取文件')
+    }
+    return
   }
+  showToast('未识别到可导入的内容')
 }
 
 // ESC：右键菜单 → 整理模式 → 隐藏窗口

--- a/src/webui.py
+++ b/src/webui.py
@@ -1060,7 +1060,7 @@ class JsApi:
             return {"ok": False, "error": str(e)}
 
     def open_settings(self):
-        self._webui.open_settings()
+        return self._webui.open_settings()
 
     def lan_confirm_device(self, approved: bool) -> dict:
         from . import lan
@@ -1282,6 +1282,8 @@ def start_qqnt_extract(
 def _qqnt_worker(
     qq_number, output_dir, image_only, overwrite, ini_path, userdata_save_path
 ):
+    """后台执行 QQNT 表情提取：调用 qqnt_extract 并转发进度/错误到 _QQNT_STATE"""
+
     def on_progress(done, total, src, dst):
         pct = int(done * 100 / total) if total else 0
         _set_qqnt(progress=pct, message="复制中 %d/%d" % (done, total))
@@ -1310,7 +1312,7 @@ def _qqnt_worker(
         else:
             _set_qqnt(status="done", progress=100, message="提取完成", result=result)
     except Exception as e:
-        logger.error(f"qqnt extract error: {e}")
+        logger.error("qqnt extract error: %s", e)
         _set_qqnt(status="error", message="提取失败", error=str(e))
 
 
@@ -2754,7 +2756,7 @@ class WebUI:
         return True
 
     def open_settings(self):
-        self._create_settings_window()
+        return self._create_settings_window()
 
     def _create_settings_window(self):
         try:
@@ -2776,8 +2778,10 @@ class WebUI:
                 frameless=True,
                 easy_drag=False,
             )
+            return True
         except Exception as e:
             logger.warning(f"create settings window error: {e}")
+            return False
 
     def close_settings(self):
         if self._settings_window:

--- a/src/webui.py
+++ b/src/webui.py
@@ -1310,6 +1310,7 @@ def _qqnt_worker(
         else:
             _set_qqnt(status="done", progress=100, message="提取完成", result=result)
     except Exception as e:
+        logger.error(f"qqnt extract error: {e}")
         _set_qqnt(status="error", message="提取失败", error=str(e))
 
 

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -984,9 +984,6 @@ async function startDYImport() {
       } else if (s.status === 'error') {
         document.getElementById('dy-import-title').textContent = '导入失败';
         if (dyPollTimer) { clearInterval(dyPollTimer); dyPollTimer = null; }
-        const el = document.getElementById('dy-status');
-        el.textContent = '导入失败: ' + (s.error || '');
-        el.className = 'error';
         let hint = s.error || '未知错误';
         if (s.error_code === 'login_failed') {
           hint += '；请从浏览器抖音网页版重新复制 Cookie 后重试';
@@ -995,6 +992,9 @@ async function startDYImport() {
         } else if (s.error_code === 'no_stickers') {
           hint += '；请确认抖音收藏的自定义表情包存在';
         }
+        const el = document.getElementById('dy-status');
+        el.textContent = '导入失败: ' + hint;
+        el.className = 'error';
         document.getElementById('dy-import-error').style.display = '';
         document.getElementById('dy-import-error').textContent = hint;
         btn.disabled = false;

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -987,8 +987,16 @@ async function startDYImport() {
         const el = document.getElementById('dy-status');
         el.textContent = '导入失败: ' + (s.error || '');
         el.className = 'error';
+        let hint = s.error || '未知错误';
+        if (s.error_code === 'login_failed') {
+          hint += '；请从浏览器抖音网页版重新复制 Cookie 后重试';
+        } else if (s.error_code === 'sign_failed') {
+          hint += '；请稍后重试，或更新 Cookie 后再试';
+        } else if (s.error_code === 'no_stickers') {
+          hint += '；请确认抖音收藏的自定义表情包存在';
+        }
         document.getElementById('dy-import-error').style.display = '';
-        document.getElementById('dy-import-error').textContent = s.error || '未知错误';
+        document.getElementById('dy-import-error').textContent = hint;
         btn.disabled = false;
       } else if (s.status === 'cancelled') {
         document.getElementById('dy-import-title').textContent = '已取消';
@@ -1124,10 +1132,14 @@ async function startTGImport() {
         document.getElementById('tg-import-title').textContent = '导入失败';
         if (tgPollTimer) { clearInterval(tgPollTimer); tgPollTimer = null; }
         const el = document.getElementById('tg-status');
-        el.textContent = '导入失败: ' + (s.error || '');
+        let errMsg = s.error || '未知错误';
+        if (s.error_code === 'no_ffmpeg') {
+          errMsg += '；安装 ffmpeg 后可重试，或取消勾选「WebM 转 WebP」直接导入静态贴纸';
+        }
+        el.textContent = '导入失败: ' + errMsg;
         el.className = 'error';
         document.getElementById('tg-import-error').style.display = '';
-        document.getElementById('tg-import-error').textContent = s.error || '未知错误';
+        document.getElementById('tg-import-error').textContent = errMsg;
         if (['no_tdata', 'invalid_tdata', 'no_cache'].includes(s.error_code)) {
           document.getElementById('btn-tg-retry').style.display = '';
         }
@@ -1333,10 +1345,16 @@ async function startWechatImport() {
         if (wechatPollTimer) { clearInterval(wechatPollTimer); wechatPollTimer = null; }
         const el = document.getElementById('wechat-status');
         const errCode = s.error_code ? ' [' + s.error_code + ']' : '';
-        el.textContent = '导入失败: ' + (s.error || '未知错误') + errCode;
+        let errMsg = s.error || '未知错误';
+        if (s.error_code === 'no_binary') {
+          errMsg += '；请检查网络后重试（需从 GitHub 下载辅助工具）';
+        } else if (s.error_code === 'no_key') {
+          errMsg += '；请确认微信已登录且为支持的版本';
+        }
+        el.textContent = '导入失败: ' + errMsg + errCode;
         el.className = 'error';
         document.getElementById('wechat-import-error').style.display = '';
-        document.getElementById('wechat-import-error').textContent = (s.error || '未知错误') + errCode;
+        document.getElementById('wechat-import-error').textContent = errMsg + errCode;
         wechatSetCloseLabel('关闭');
         btn.disabled = false;
       } else if (s.status === 'cancelled') {

--- a/src/wechat_probe.py
+++ b/src/wechat_probe.py
@@ -806,6 +806,11 @@ def _wechat_worker(webui, user_root, download, account_path):
             return
         env = inspect_wechat_environment(user_root)
         if env.get("status") not in _PROCEEDABLE:
+            logger.error(
+                "wechat import: 环境检测失败 status=%s reason=%s",
+                env.get("status"),
+                env.get("reason"),
+            )
             _update_wechat(
                 status="error",
                 error_code=env.get("status", "unknown"),
@@ -816,6 +821,7 @@ def _wechat_worker(webui, user_root, download, account_path):
         if not account:
             multi = env.get("account_directory_count", 0) > 1
             error_msg = "检测到多个微信账号，请选择账号" if multi else "未找到可用账号"
+            logger.error("wechat import: %s", error_msg)
             _update_wechat(
                 status="error",
                 error_code="multiple_accounts",
@@ -824,6 +830,7 @@ def _wechat_worker(webui, user_root, download, account_path):
             return
         db_path = account["db_path"]
         if not db_path:
+            logger.error("wechat import: 未找到表情数据库: %s", account.get("path"))
             _update_wechat(
                 status="error",
                 error_code="no_database",
@@ -843,6 +850,7 @@ def _wechat_worker(webui, user_root, download, account_path):
                 return
             binary_path = ensure_wechat_keyfinder()
             if not binary_path:
+                logger.error("wechat import: helper 二进制不可用")
                 _update_wechat(
                     status="error",
                     error_code="no_binary",
@@ -864,9 +872,11 @@ def _wechat_worker(webui, user_root, download, account_path):
                     error_code=result.get("reason", "keyfinder_failed"),
                     error=detail or "密钥提取失败",
                 )
+                logger.error("wechat import: 密钥提取失败: %s", detail)
                 return
             key = result.get("key", "")
             if not key:
+                logger.error("wechat import: 无法提取加密密钥")
                 _update_wechat(
                     status="error",
                     error_code="no_key",


### PR DESCRIPTION
## 背景
导入功能此前存在两类问题：
1. **错误不写日志** — TG/抖音/微信/QQ 导入的错误只显示在 GUI 覆盖层，不打 `logger`，用户反馈问题时无法从日志定位（此前 `OhMyMeme-logs.txt` 全是 PIL debug，找不到导入错误）
2. **静默失败** — 主窗口拖放导入在多种失败场景下完全无反馈；抖音部分下载失败不提示；部分错误码无操作指引

## 修复内容

### 1. 导入错误统一写日志（5 个模块，31 处）
| 模块 | 覆盖的错误 |
|------|-----------|
| `tg_stickers.py` | invalid_tdata / no_tdata / key_datas 缺失 / bad_key / no_cache / no_ffmpeg |
| `douyin.py` | login_failed / sign_failed / no_stickers |
| `wechat_probe.py` | 环境检测失败 / 多账号 / 无数据库 / no_binary / keyfinder 失败 / no_key |
| `adb_util.py` | 平台不支持 / 解压失败 / ADB 启动失败 / 无设备 / 目录检测失败 / 拉取失败 / 打包失败 |
| `webui.py` | qqnt extract 异常 |

此前这些错误**只写 GUI 状态不打日志**，现在全部 `logger.error` 记录。

### 2. 主窗口拖放导入消除静默失败（App.vue）
| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 拖入文件但下载原图失败 | 静默 | toast 错误详情 |
| 拖入文件但上传失败 / 非 2xx | 静默 | toast「导入失败：服务器返回错误」 |
| 文件读取失败 | 静默 | toast「导入失败：无法读取文件」 |
| 拖入无效内容（非文件非 URL） | 完全静默 | toast「未识别到可导入的内容」 |
| 打开设置窗口失败 | 静默 | toast「无法打开设置窗口」 |

### 3. 抖音部分下载失败提示（douyin.py）
- 新增 `download_failed` 计数，完成消息体现「N 个下载失败」（此前只报成功/跳过）

### 4. 错误码操作指引（settings.js）
| 导入 | 错误码 | 新增指引 |
|------|--------|---------|
| 抖音 | login_failed | 重新从浏览器复制 Cookie 后重试 |
| 抖音 | sign_failed | 稍后重试，或更新 Cookie |
| 抖音 | no_stickers | 确认收藏的自定义表情包存在 |
| 微信 | no_binary | 需从 GitHub 下载辅助工具，检查网络 |
| 微信 | no_key | 确认微信已登录且为支持版本 |
| TG | no_ffmpeg | 安装 ffmpeg，或取消勾选转换直接导入 |

### 5. 本地契约校验脚本（不上传）
- 新增 `scripts/check_contract.py`（已加 .gitignore）：静态校验 `evaluate_js`→前端全局函数、主窗口→JsApi、设置窗口→SettingsApi 三类前后端契约，防止重构回归

## 影响范围
```
 .gitignore            |  3 +++
 src/adb_util.py       | 12 ++++++++++++
 src/douyin.py         | 13 ++++++++++++-
 src/tg_stickers.py    | 38 ++++++++++++++++++++++++++++++++++----
 src/vue-src/App.vue   | 24 ++++++++++++++++++++----
 src/webui.py          |  1 +
 src/webui/settings.js | 28 +++++++++++++++++++++++-----
 src/wechat_probe.py   | 10 ++++++++++
 8 files changed, 115 insertions(+), 14 deletions(-)
```

## 验证
- `python -m pytest tests/` — **191 passed**
- `ruff check src/`、`black --check src/` — 全部通过
- `npx vite build` + JS 语法校验通过
- 契约校验脚本正负向测试通过（缺失时退出 1，正常 0）

## 备注
- 保留合理的静默（不打扰用户）：更新检查失败、窗口控制回退、设置窗口刷新主窗口
- 前端产物 `dist/` 由 CI/构建自动编译（gitignored）

## Summary by Sourcery

通过记录后端故障并为以前静默的错误路径提供可执行的反馈，提升导入的可靠性和可诊断性。

新功能：
- 为常见的抖音、微信和 Telegram 导入错误提供可执行的指导。
- 在导入完成结果中报告抖音下载失败情况。
- 显示 Telegram 去重和批量导入的进度。

错误修复：
- 确保 Telegram、抖音、微信、QQ 和 QQNT 的导入失败都会记录在应用日志中，以便诊断。
- 将拖拽导入和设置窗口中原本静默的失败替换为面向用户的错误通知。

增强改进：
- 传播设置窗口创建结果，使主窗口能够报告失败。
- 通过更清晰的错误细节和操作进度信息，改进导入状态报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve import reliability and diagnosability by logging backend failures and surfacing actionable feedback for previously silent error paths.

New Features:
- Provide actionable guidance for common Douyin, WeChat, and Telegram import errors.
- Report failed Douyin downloads in import completion results.
- Show progress for Telegram deduplication and batched importing.

Bug Fixes:
- Ensure import failures across Telegram, Douyin, WeChat, QQ, and QQNT are recorded in application logs for diagnosis.
- Replace silent drag-and-drop and settings-window failures with user-facing error notifications.

Enhancements:
- Propagate settings-window creation results so the main window can report failures.
- Improve import status reporting with clearer error details and operation progress.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过记录后端故障并为以前静默的错误路径提供可执行的反馈，提升导入的可靠性和可诊断性。

新功能：
- 为常见的抖音、微信和 Telegram 导入错误提供可执行的指导。
- 在导入完成结果中报告抖音下载失败情况。
- 显示 Telegram 去重和批量导入的进度。

错误修复：
- 确保 Telegram、抖音、微信、QQ 和 QQNT 的导入失败都会记录在应用日志中，以便诊断。
- 将拖拽导入和设置窗口中原本静默的失败替换为面向用户的错误通知。

增强改进：
- 传播设置窗口创建结果，使主窗口能够报告失败。
- 通过更清晰的错误细节和操作进度信息，改进导入状态报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve import reliability and diagnosability by logging backend failures and surfacing actionable feedback for previously silent error paths.

New Features:
- Provide actionable guidance for common Douyin, WeChat, and Telegram import errors.
- Report failed Douyin downloads in import completion results.
- Show progress for Telegram deduplication and batched importing.

Bug Fixes:
- Ensure import failures across Telegram, Douyin, WeChat, QQ, and QQNT are recorded in application logs for diagnosis.
- Replace silent drag-and-drop and settings-window failures with user-facing error notifications.

Enhancements:
- Propagate settings-window creation results so the main window can report failures.
- Improve import status reporting with clearer error details and operation progress.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Telegram 导入支持分批处理并实时更新进度。
  * 抖音导入完成信息显示跳过及下载失败数量。
  * 动态表情转换后支持自动去重。

* **错误修复**
  * 改进抖音、Telegram、微信及 QQ 表情导入失败提示。
  * 优化设置、拖放导入和文件上传的异常处理。
  * 增强对登录失败、工具缺失、设备异常及下载失败等情况的反馈。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->