### PR TITLE
feat: 导入体验增强 + 感知哈希相似去重重构

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ src/              # 主代码
     types/       # TS 类型定义 (Meme/Collection/Tag)
     utils/       # api 桥接 + esc + renderMarkdown
     composables/ # useMemes 状态 / useDragSort 拖拽 / useContextMenu / useCollectionBuilder
-    components/  # Pager/TagEditor/ImportMenu/SyncOverlay/ContextMenu/CollectionBuilder/
-                 # CollectionTreeNode/UpdateDialog
+    components/  # Pager/TagEditor/ImportMenu/ImportProgressOverlay/SyncOverlay/
+                 # ContextMenu/CollectionBuilder/CollectionTreeNode/UpdateDialog/SimilarImportDialog
   webui/          # 前端静态文件
     vue.html      # 主窗口入口（Vue），Bottle 优先加载
     dist/ohmymeme.js # Vite 构建产物（gitignored）
@@ -98,6 +98,8 @@ tests/
   test_tg_stickers.py # unittest 风格: Telegram webm转换/取消/进度/dedup (mock Popen)
   test_updater.py   # unittest 风格: 非阻塞版本检查缓存机制 (mock check_latest)
   test_startup.py # pytest 风格: 全生命周期集成测试
+  test_phash.py   # pytest 风格: 感知哈希(pHash)算法单元测试 (需 PIL)
+  test_import_concurrency.py # pytest 风格: _do_import 并发去重 (同图1条/异图都可导)
   fixtures/grid_slot_probe.cjs # Node 网格拖拽槽位回归探针
 ```
 
@@ -222,8 +224,10 @@ tests/
   3. 按哈希查 DB (`get_by_hash`) 跳过重复内容
 - **双重去重** — 文件名去重防止每次启动重复注册，哈希去重防止同图不同名重复
 - `_do_import`（拖入/导入对话框）同样有哈希去重，且文件重命名为 `{hash[:16]}{ext}`
+- **感知哈希相似去重**（`download_original_image` 单图导入路径）：`memes.perceptual_hash` 列（TEXT 存 16 进制，旧库自动 ALTER 迁移）持久化每张图的 64 位感知哈希（`_perceptual_hash`，8x8 可分离 DCT pHash，比均值哈希对浅色/低信息图判别力更强）。导入时哈希未命中则 `_find_similar_candidates` **只算新图 phash + 从 DB 读存量 phash 比对**（整数 XOR，微秒级），`perceptual_hash` 为空的旧库行惰性回填：缺失 ≤`_PHASH_SYNC_BACKFILL_MAX`(5) 同步回填，超过则丢后台线程（`_PHASH_BACKFILLING` 防重入，start 异常复位），本次只比对已填的。`_build_cache_index` 一次性构建文件索引避免逐行 walk（仅在有缺失时执行）。汉明距离 `_PHASH_SIMILAR_DIST<=12` 视为近似，**全库比对无截断漏检**。命中候选时将文件复制到独立临时文件登记 `_PENDING_SIMILAR`（token 随机、TTL 300s 过期时在 pop/next-register 时删除临时文件），返回 `similar_pending`，前端 `SimilarImportDialog` 弹窗让用户选：保留新图 / 保留旧图 / 跳过（discard）/ 都保留（keep_both），经 `JsApi.resolve_similar_import(token, action)` 决定导入或放弃。哈希精确命中返回 `duplicate` 提示「已存在」。`_do_import`/`scan_cache` 新建时写入 `perceptual_hash`（`add_meme` 内部转 hex，规避 64 位溢出 SQLite INTEGER）。两条单图交互路径都启用：`download_original_image`（URL 拖放/下载原图）与 `/api/upload/`（File 拖放，单张时走 `_import_with_similar_decision`）；批量路径（多文件拖放/文件夹/同步 pull/LAN）不做感知去重（多文件走 `_do_import` 避免逐个打断）。`_do_import` 去重关键区（`get_by_hash`检查→copy2→`add_meme`→回查）由模块级 `_IMPORT_LOCK` 串行化：并发拖入完全相同字节的图也不产生重复记录（测试 `test_import_concurrency.py`）
 - **导入限制**：`config.py` 常量 `_IMPORT_MAX_PX=2560`（最长边）/`_IMPORT_MAX_BYTES=20MiB`，超过即拒绝接收；覆盖 `_do_import`、`scan_cache`、同步 `_pull_worker`、LAN `_import_bytes` 四类接收路径，跳过超限文件并计数（前端 toast 提示）
-- **文件夹导入** (`JsApi.import_folder`)：FOLDER 对话框 → `os.walk` 递归收集图片（扩展名过滤）→ 复用 `_do_import`；`make_collection`（前端导入菜单「自动创建分组」勾选，默认开）时以文件夹名 `create_collection` + 批量 `add_to_collection`（同名分组复用，重复导入并入），导入菜单入口 `importFolder()` 复用 `pending` 并发锁
+- **文件夹导入** (`JsApi.import_folder`)：FOLDER 对话框 → `os.walk` 递归收集图片（扩展名过滤）→ **后台线程导入**（`start_import_job` + `_IMPORT_JOB_STATE`，前端 `ImportProgressOverlay` 300ms 轮询进度条 + 取消，取消时 `progress_cb` 返回 False 中断 `_do_import`，保留实际进度）→ `make_collection`（前端导入菜单「自动创建分组」勾选，默认开）时以文件夹名 `create_collection` + 批量 `add_to_collection`（同名分组复用，重复导入并入）。`import_memes`（文件对话框）同样后台化，走同一 job；`import_from_clipboard`（剪贴板，通常单张瞬时）保持同步返回 id。`_do_import` 提供可选 `progress_cb`（逐文件回调，返回 False 中断）
+- **渠道自动分组**：3 个入库渠道导入后调 `WebUI.ensure_import_collection(ids, 固定名)` 自动归入固定名分组——TG→「Telegram」、抖音→「抖音」、微信→「微信」；同一渠道不同时间导入复用同名分组。QQ（导出 ZIP 到外部）、QQNT（提取到输出文件夹）不入库故不建组。`create_collection` 现为「先按 name+parent_id 查已存在→返回既有 id，否则 INSERT」——**不再产生重复空分组**（仓库同名字段多次导入只一个分组，成员靠 meme_collections 的 PRIMARY KEY 去重），测试 `test_ensure_collection_same_name_reused`/`empty_args`
 
 ### 剪贴板 (GIF/WebP 直接传送)
 - `_copy_gif_windows` 同时写入三个剪贴板格式:

--- a/src/database.py
+++ b/src/database.py
@@ -198,7 +198,7 @@ class MemeDB:
             "original_name",
             "stego_of_hash",
             "from_stego",
-            "perceptual_hash",
+            # perceptual_hash 不在此列：写统一走 set_perceptual_hash（hex 序列化）
         }
         sets = []
         vals = []

--- a/src/database.py
+++ b/src/database.py
@@ -45,6 +45,7 @@ class MemeDB:
                 sort_order  INTEGER DEFAULT 0,
                 stego_of_hash TEXT DEFAULT NULL,
                 from_stego  INTEGER DEFAULT 0,
+                perceptual_hash TEXT DEFAULT NULL,
                 created_at  TEXT    NOT NULL DEFAULT (datetime('now','localtime')),
                 updated_at  TEXT    NOT NULL DEFAULT (datetime('now','localtime'))
             );
@@ -96,6 +97,7 @@ class MemeDB:
             ("memes", "sort_order", "INTEGER DEFAULT 0"),
             ("memes", "stego_of_hash", "TEXT DEFAULT NULL"),
             ("memes", "from_stego", "INTEGER DEFAULT 0"),
+            ("memes", "perceptual_hash", "TEXT DEFAULT NULL"),
             (
                 "collections",
                 "parent_id",
@@ -135,14 +137,17 @@ class MemeDB:
         tags: List[str] = None,
         stego_of_hash: str = None,
         from_stego: int = 0,
+        perceptual_hash: int = None,
     ) -> int:
         with self._lock:
             conn = self._get_conn()
+            ph_hex = hex(perceptual_hash) if perceptual_hash is not None else None
             cur = conn.execute(
                 """INSERT INTO memes
                    (filename, file_hash, width, height,
-                    file_size, mime_type, original_name, stego_of_hash, from_stego)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    file_size, mime_type, original_name, stego_of_hash, from_stego,
+                    perceptual_hash)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     filename,
                     file_hash,
@@ -153,6 +158,7 @@ class MemeDB:
                     original_name,
                     stego_of_hash,
                     from_stego,
+                    ph_hex,
                 ),
             )
             meme_id = cur.lastrowid
@@ -187,6 +193,7 @@ class MemeDB:
             "original_name",
             "stego_of_hash",
             "from_stego",
+            "perceptual_hash",
         }
         sets = []
         vals = []
@@ -283,22 +290,30 @@ class MemeDB:
     # --- 收藏集 ---
 
     def create_collection(self, name: str, parent_id: int = None) -> int:
+        """创建分组；同名(parent_id)已存在则直接返回其 id（不产生重复空分组）"""
         with self._lock:
             conn = self._get_conn()
             if parent_id is not None:
+                row = conn.execute(
+                    "SELECT id FROM collections WHERE name=? AND parent_id=?",
+                    (name, parent_id),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT id FROM collections WHERE name=? AND parent_id IS NULL",
+                    (name,),
+                ).fetchone()
+            if row:
+                return row[0]
+            if parent_id is not None:
                 conn.execute(
-                    "INSERT OR IGNORE INTO collections (name, parent_id) VALUES (?, ?)",
+                    "INSERT INTO collections (name, parent_id) VALUES (?, ?)",
                     (name, parent_id),
                 )
             else:
-                conn.execute(
-                    "INSERT OR IGNORE INTO collections (name) VALUES (?)", (name,)
-                )
+                conn.execute("INSERT INTO collections (name) VALUES (?)", (name,))
             conn.commit()
-            row = conn.execute(
-                "SELECT id FROM collections WHERE name=?", (name,)
-            ).fetchone()
-            return row[0] if row else -1
+            return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
 
     def add_to_collection(self, meme_id: int, collection_id: int):
         with self._lock:
@@ -573,6 +588,27 @@ class MemeDB:
             (limit, offset),
         ).fetchall()
         return [dict(r) for r in rows]
+
+    def get_all_phash(self) -> List[dict]:
+        """返回所有可见 meme 的感知哈希快照，供全库相似度比对（排除隐写载体）"""
+        with self._lock:
+            conn = self._get_conn()
+            rows = conn.execute(
+                "SELECT id, filename, original_name, perceptual_hash, stego_of_hash "
+                "FROM memes WHERE (stego_of_hash IS NULL OR stego_of_hash = '') "
+                "ORDER BY sort_order ASC"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def set_perceptual_hash(self, meme_id: int, phash: int):
+        """写入/更新某 meme 的感知哈希（hex 文本存储，惰性回填用）"""
+        ph_hex = hex(phash) if phash is not None else None
+        with self._lock:
+            conn = self._get_conn()
+            conn.execute(
+                "UPDATE memes SET perceptual_hash=? WHERE id=?", (ph_hex, meme_id)
+            )
+            conn.commit()
 
     def reorder_memes(self, meme_ids: List[int]):
         with self._lock:

--- a/src/database.py
+++ b/src/database.py
@@ -141,7 +141,12 @@ class MemeDB:
     ) -> int:
         with self._lock:
             conn = self._get_conn()
-            ph_hex = hex(perceptual_hash) if perceptual_hash is not None else None
+            if perceptual_hash:
+                ph_hex = hex(perceptual_hash)
+            elif perceptual_hash == 0:
+                ph_hex = "0"  # 已计算但无感知内容：占位，避免反复回填
+            else:
+                ph_hex = None
             cur = conn.execute(
                 """INSERT INTO memes
                    (filename, file_hash, width, height,
@@ -602,7 +607,12 @@ class MemeDB:
 
     def set_perceptual_hash(self, meme_id: int, phash: int):
         """写入/更新某 meme 的感知哈希（hex 文本存储，惰性回填用）"""
-        ph_hex = hex(phash) if phash is not None else None
+        if phash:
+            ph_hex = hex(phash)
+        elif phash == 0:
+            ph_hex = "0"  # 已计算但无感知内容：占位，避免反复回填
+        else:
+            ph_hex = None
         with self._lock:
             conn = self._get_conn()
             conn.execute(

--- a/src/douyin.py
+++ b/src/douyin.py
@@ -378,8 +378,10 @@ def start_douyin_import(webui, cookie: str) -> bool:
                 imported = len(result.get("ids", []))
                 rejected = result.get("rejected", 0)
                 if imported:
-                    # 自动归入「抖音」分组（同名复用）
-                    webui.ensure_import_collection(result.get("ids", []), "抖音")
+                    try:
+                        webui.ensure_import_collection(result.get("ids", []), "抖音")
+                    except Exception as e:
+                        logger.error("douyin 自动分组失败: %s", e)
                 msg = f"导入完成：{imported} 个成功"
                 if rejected:
                     msg += f"，{rejected} 个跳过"

--- a/src/douyin.py
+++ b/src/douyin.py
@@ -377,6 +377,9 @@ def start_douyin_import(webui, cookie: str) -> bool:
                 result = webui._do_import(downloaded)
                 imported = len(result.get("ids", []))
                 rejected = result.get("rejected", 0)
+                if imported:
+                    # 自动归入「抖音」分组（同名复用）
+                    webui.ensure_import_collection(result.get("ids", []), "抖音")
                 msg = f"导入完成：{imported} 个成功"
                 if rejected:
                     msg += f"，{rejected} 个跳过"

--- a/src/tg_stickers.py
+++ b/src/tg_stickers.py
@@ -769,8 +769,10 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
             )
         imported = len(imported_ids)
         if imported:
-            # 自动归入「Telegram」分组（同名复用）
-            webui.ensure_import_collection(imported_ids, "Telegram")
+            try:
+                webui.ensure_import_collection(imported_ids, "Telegram")
+            except Exception as e:
+                logger.error("tg 自动分组失败: %s", e)
         msg = f"导入完成，共 {imported} 个表情"
         if convert_failed:
             msg += f"（{convert_failed} 个 WebM 转换失败已跳过）"

--- a/src/tg_stickers.py
+++ b/src/tg_stickers.py
@@ -768,6 +768,9 @@ def _tg_worker(webui, tdata_path, passcode, convert_webm):
                 done=min(i + batch, total),
             )
         imported = len(imported_ids)
+        if imported:
+            # 自动归入「Telegram」分组（同名复用）
+            webui.ensure_import_collection(imported_ids, "Telegram")
         msg = f"导入完成，共 {imported} 个表情"
         if convert_failed:
             msg += f"（{convert_failed} 个 WebM 转换失败已跳过）"

--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -75,6 +75,7 @@ const sidebarCollapsed = ref(false)
 const dragOver = ref(false)
 let dragCounter = 0
 let nativeDragActive = false
+let dragGeneration = 0
 let dragState: { sx: number; sy: number; px: number; py: number; raf: number | null } | null = null
 let updateInterval: ReturnType<typeof setInterval> | null = null
 
@@ -285,8 +286,11 @@ async function onTitlebarMouseDown(e: MouseEvent) {
   if (e.button !== 0) return
   if ((e.target as HTMLElement).closest('.title-btn') || (e.target as HTMLElement).closest('.icon-btn') || (e.target as HTMLElement).closest('.sidebar-toggle')) return
   try {
+    const gen = dragGeneration
     const nativeDrag = await window.pywebview?.api?.start_window_drag(e.button + 1, e.screenX, e.screenY)
     if (nativeDrag) return
+    // await 期间可能已松开鼠标（onWindowMouseUp 已递增 generation）：此时不再启动拖动
+    if (gen !== dragGeneration) return
   } catch (_) {}
   dragState = { sx: e.screenX, sy: e.screenY, px: 0, py: 0, raf: null }
   e.preventDefault()
@@ -314,6 +318,7 @@ function onWindowMouseUp() {
   if (dragState?.raf) cancelAnimationFrame(dragState.raf)
   try { window.pywebview?.api?.stop_window_drag() } catch (_) {}
   dragState = null
+  dragGeneration++  // 使未完成的 mousedown await 失效，防止松手后仍启动拖动
 }
 
 function onMemeRightClick(e: MouseEvent, meme: Meme) {

--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -706,8 +706,9 @@ async function onDrop(e: DragEvent) {
     try {
       const r = await window.pywebview?.api?.download_original_image(uri)
       if (r?.ok) { showToast('导入成功'); search(); refreshCollections(); return }
+      if (r?.duplicate) { showToast('该图片已存在'); return }
       if (r?.similar_pending) {
-        const action = await similarImportDialog.value?.open(r.candidates || [], r.truncated, r.scan_limit)
+        const action = await similarImportDialog.value?.open(r.candidates || [])
         if (action) {
           const rr = await window.pywebview?.api?.resolve_similar_import(r.token, action)
           if (rr?.ok && rr.imported) { showToast('导入成功'); search(); refreshCollections() }
@@ -741,7 +742,7 @@ async function onDrop(e: DragEvent) {
       let j: any = null
       try { j = await res.json() } catch (_) { j = null }
       if (j?.similar_pending) {
-        const action = await similarImportDialog.value?.open(j.candidates || [], j.truncated, j.scan_limit)
+        const action = await similarImportDialog.value?.open(j.candidates || [])
         if (action) {
           const rr = await window.pywebview?.api?.resolve_similar_import(j.token, action)
           if (rr?.ok && rr.imported) { showToast('导入成功'); search(); refreshCollections() }

--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -9,8 +9,10 @@ import CollectionBuilder from './components/CollectionBuilder.vue'
 import CollectionTreeNode from './components/CollectionTreeNode.vue'
 import ConfirmDialog from './components/ConfirmDialog.vue'
 import ImportMenu from './components/ImportMenu.vue'
+import ImportProgressOverlay from './components/ImportProgressOverlay.vue'
 import InputDialog from './components/InputDialog.vue'
 import Pager from './components/Pager.vue'
+import SimilarImportDialog from './components/SimilarImportDialog.vue'
 import SyncOverlay from './components/SyncOverlay.vue'
 import TagEditor from './components/TagEditor.vue'
 import UpdateDialog from './components/UpdateDialog.vue'
@@ -23,6 +25,7 @@ const tagEditor = ref<InstanceType<typeof TagEditor> | null>(null)
 const updateDialog = ref<InstanceType<typeof UpdateDialog> | null>(null)
 const inputDialog = ref<InstanceType<typeof InputDialog> | null>(null)
 const confirmDialog = ref<InstanceType<typeof ConfirmDialog> | null>(null)
+const similarImportDialog = ref<InstanceType<typeof SimilarImportDialog> | null>(null)
 
 // 统一确认对话框（替代原生 confirm，风格与重构主题一致）
 async function confirmAsk(title: string, message: string): Promise<boolean> {
@@ -72,7 +75,7 @@ const sidebarCollapsed = ref(false)
 const dragOver = ref(false)
 let dragCounter = 0
 let nativeDragActive = false
-let dragState: { sx: number; sy: number } | null = null
+let dragState: { sx: number; sy: number; px: number; py: number; raf: number | null } | null = null
 let updateInterval: ReturnType<typeof setInterval> | null = null
 
 // 启动动画：仅页面首次加载（启动）时播放一次，快捷键呼出不重载页面故不重复播放
@@ -246,6 +249,12 @@ function onImportDone() {
   refreshCollections()
 }
 
+const importProgress = ref<InstanceType<typeof ImportProgressOverlay> | null>(null)
+
+function onImporting() {
+  importProgress.value?.start()
+}
+
 const syncOverlay = ref<InstanceType<typeof SyncOverlay> | null>(null)
 
 function syncUpload() {
@@ -279,22 +288,33 @@ async function onTitlebarMouseDown(e: MouseEvent) {
     const nativeDrag = await window.pywebview?.api?.start_window_drag(e.button + 1, e.screenX, e.screenY)
     if (nativeDrag) return
   } catch (_) {}
-  dragState = { sx: e.screenX, sy: e.screenY }
+  dragState = { sx: e.screenX, sy: e.screenY, px: 0, py: 0, raf: null }
   e.preventDefault()
 }
 
 function onWindowMouseMove(e: MouseEvent) {
   if (!dragState) return
-  const dx = e.screenX - dragState.sx
-  const dy = e.screenY - dragState.sy
-  if (dx !== 0 || dy !== 0) {
-    try { window.pywebview?.api?.move_window(dx, dy) } catch (_) {}
-    dragState.sx = e.screenX
-    dragState.sy = e.screenY
-  }
+  // 记录相对拖动起点的总偏移（屏幕坐标，自愈无累积滞后）
+  dragState.px = e.screenX - dragState.sx
+  dragState.py = e.screenY - dragState.sy
+  // rAF 合并每帧最新位置，避免高回报率鼠标消息风暴堵塞桥接
+  if (dragState.raf) return
+  dragState.raf = requestAnimationFrame(() => {
+    if (!dragState) return
+    dragState.raf = null
+    const dx = dragState.px
+    const dy = dragState.py
+    if (dx !== 0 || dy !== 0) {
+      try { window.pywebview?.api?.move_window(dx, dy) } catch (_) {}
+    }
+  })
 }
 
-function onWindowMouseUp() { dragState = null }
+function onWindowMouseUp() {
+  if (dragState?.raf) cancelAnimationFrame(dragState.raf)
+  try { window.pywebview?.api?.stop_window_drag() } catch (_) {}
+  dragState = null
+}
 
 function onMemeRightClick(e: MouseEvent, meme: Meme) {
   e.preventDefault()
@@ -686,6 +706,16 @@ async function onDrop(e: DragEvent) {
     try {
       const r = await window.pywebview?.api?.download_original_image(uri)
       if (r?.ok) { showToast('导入成功'); search(); refreshCollections(); return }
+      if (r?.similar_pending) {
+        const action = await similarImportDialog.value?.open(r.candidates || [], r.truncated, r.scan_limit)
+        if (action) {
+          const rr = await window.pywebview?.api?.resolve_similar_import(r.token, action)
+          if (rr?.ok && rr.imported) { showToast('导入成功'); search(); refreshCollections() }
+          else if (rr?.ok) { showToast('已跳过该图片') }
+          else { showToast(rr?.error || '处理失败') }
+        }
+        return
+      }
       showToast(r?.error || '导入失败')
       return
     } catch (_) {
@@ -708,8 +738,21 @@ async function onDrop(e: DragEvent) {
     }
     try {
       const res = await fetch('/api/upload/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files: [{ name: file.name, data: b64 }] }) })
-      if (res.ok) { showToast('导入成功'); search(); refreshCollections() }
-      else { showToast('导入失败：服务器返回错误') }
+      let j: any = null
+      try { j = await res.json() } catch (_) { j = null }
+      if (j?.similar_pending) {
+        const action = await similarImportDialog.value?.open(j.candidates || [], j.truncated, j.scan_limit)
+        if (action) {
+          const rr = await window.pywebview?.api?.resolve_similar_import(j.token, action)
+          if (rr?.ok && rr.imported) { showToast('导入成功'); search(); refreshCollections() }
+          else if (rr?.ok) { showToast('已跳过该图片') }
+          else { showToast(rr?.error || '处理失败') }
+        }
+        return
+      }
+      if (j?.duplicate) { showToast('该图片已存在'); return }
+      if (res.ok || j?.ok) { showToast('导入成功'); search(); refreshCollections() }
+      else { showToast(j?.error || '导入失败：服务器返回错误') }
     } catch (_) {
       showToast('导入失败：网络或服务异常')
     }
@@ -973,12 +1016,14 @@ onUnmounted(() => {
   </div>
 
   <CollectionBuilder />
-  <ImportMenu ref="importMenu" @imported="onImportDone" />
+  <ImportMenu ref="importMenu" @imported="onImportDone" @importing="onImporting" />
+  <ImportProgressOverlay ref="importProgress" @imported="onImportDone" />
   <SyncOverlay ref="syncOverlay" @synced="onSyncDone" />
   <TagEditor ref="tagEditor" />
   <UpdateDialog ref="updateDialog" />
   <InputDialog ref="inputDialog" />
   <ConfirmDialog ref="confirmDialog" />
+  <SimilarImportDialog ref="similarImportDialog" />
   <ContextMenu
     :visible="ctx.visible.value" :x="ctx.x.value" :y="ctx.y.value"
     :items="ctx.items.value" :trigger="ctx.trigger.value"

--- a/src/vue-src/components/ImportMenu.vue
+++ b/src/vue-src/components/ImportMenu.vue
@@ -4,6 +4,7 @@ import { api } from '../utils/api'
 
 const emit = defineEmits<{
   imported: []
+  importing: []
   error: [msg: string]
 }>()
 
@@ -29,10 +30,11 @@ async function importLocal() {
   try {
     const result = await api('import_memes')
     if (result?.ok) {
+      if (result.async) { emit('importing'); return }  // 后台导入，覆盖层轮询
       emit('imported')
-      showToast(appendRejected(result.imported > 0 ? '导入完成' : '未导入文件', result.rejected))
+      showToast(result.imported > 0 ? '导入完成' : '未导入文件')
     } else if (!result?.cancelled) {
-      showToast('导入失败')
+      showToast(result.error || '导入失败')
     }
   } finally {
     pending.value = false
@@ -52,10 +54,9 @@ async function importFolder() {
       showToast(r.error || '导入失败')
       return
     }
-    let msg = appendRejected(r.imported > 0 ? '导入完成，共 ' + r.imported + ' 个表情' : '未导入文件', r.rejected)
-    if (r.collection_name) msg += '，已加入分组「' + r.collection_name + '」'
+    if (r.async) { emit('importing'); return }  // 后台导入，覆盖层轮询
     emit('imported')
-    showToast(msg)
+    showToast(r.imported > 0 ? '导入完成，共 ' + r.imported + ' 个表情' : '未导入文件')
   } finally {
     pending.value = false
   }

--- a/src/vue-src/components/ImportProgressOverlay.vue
+++ b/src/vue-src/components/ImportProgressOverlay.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { api } from '../utils/api'
+
+const emit = defineEmits<{
+  imported: []
+}>()
+
+const visible = ref(false)
+const pct = ref('0%')
+const msg = ref('准备中...')
+const current = ref('')
+const done = ref(0)
+const total = ref(0)
+const finished = ref(false)
+const finalMsg = ref('')
+
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function showToast(msg: string) {
+  const el = document.getElementById('toast')
+  if (!el) return
+  el.textContent = msg
+  el.classList.add('show')
+  setTimeout(() => el.classList.remove('show'), 1600)
+}
+
+function stopPolling() {
+  if (pollTimer) { clearInterval(pollTimer); pollTimer = null }
+}
+
+async function poll() {
+  let s: any = null
+  try { s = await api('get_import_progress') } catch (_) { s = null }
+  if (!s) return
+  pct.value = (s.progress || 0) + '%'
+  done.value = s.done || 0
+  total.value = s.total || 0
+  if (s.current) current.value = '正在导入: ' + s.current
+  if (!s.status || s.status === 'idle' || s.status === 'running') return
+  // 终态
+  stopPolling()
+  finished.value = true
+  if (s.status === 'done') {
+    finalMsg.value = '导入完成，共导入 ' + (s.imported || 0) + ' 个表情'
+    if (s.rejected) finalMsg.value += '，跳过 ' + s.rejected + ' 个超限文件'
+    showToast('导入完成')
+    emit('imported')
+  } else if (s.status === 'cancelled') {
+    finalMsg.value = '导入已取消'
+    showToast('导入已取消')
+  } else {
+    finalMsg.value = '导入失败: ' + (s.error || '未知错误')
+    showToast('导入失败')
+  }
+}
+
+function start() {
+  visible.value = true
+  finished.value = false
+  finalMsg.value = ''
+  pct.value = '0%'
+  msg.value = '准备中...'
+  current.value = ''
+  done.value = 0
+  total.value = 0
+  stopPolling()
+  pollTimer = setInterval(poll, 300)
+}
+
+function cancel() {
+  api('cancel_import_job').catch(() => {})
+}
+
+function background() {
+  // 后台运行：隐藏覆盖层但继续导入（不停止轮询，仅收起 UI）
+  if (finished.value) { visible.value = false; return }
+  visible.value = false
+}
+
+function close() {
+  visible.value = false
+  stopPolling()
+}
+
+defineExpose({ start })
+</script>
+
+<template>
+  <div v-if="visible" class="imp-overlay" @click.self="background">
+    <div class="imp-box">
+      <div class="imp-title">导入表情包</div>
+      <div class="imp-file">{{ finished ? finalMsg : (current || msg) }}</div>
+      <div class="imp-bar-wrap">
+        <div class="imp-bar" :style="{ width: pct }"></div>
+      </div>
+      <div class="imp-meta">
+        <span>{{ pct }}</span>
+        <span v-if="!finished && total > 0" style="margin-left:12px">{{ done }} / {{ total }}</span>
+      </div>
+      <div class="imp-actions">
+        <button v-if="!finished" class="btn btn-ghost btn-sm" @click="background">后台运行</button>
+        <button v-if="!finished" class="btn btn-ghost btn-sm" @click="cancel">取消</button>
+        <button v-if="finished" class="btn btn-primary btn-sm" @click="close">关闭</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.imp-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 510;
+  animation: fadeIn 0.15s ease;
+}
+
+.imp-box {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 24px 28px;
+  width: 400px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  text-align: center;
+}
+
+.imp-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 8px;
+}
+
+.imp-file {
+  font-size: 12px;
+  color: var(--fg-secondary);
+  margin-bottom: 12px;
+  word-break: break-all;
+  min-height: 16px;
+}
+
+.imp-bar-wrap {
+  width: 100%;
+  height: 8px;
+  background: var(--bg);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+.imp-bar {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 4px;
+  transition: width 0.3s;
+}
+
+.imp-meta {
+  font-size: 11.5px;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+
+.imp-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+</style>

--- a/src/vue-src/components/ImportProgressOverlay.vue
+++ b/src/vue-src/components/ImportProgressOverlay.vue
@@ -44,6 +44,7 @@ async function poll() {
   if (s.status === 'done') {
     finalMsg.value = '导入完成，共导入 ' + (s.imported || 0) + ' 个表情'
     if (s.rejected) finalMsg.value += '，跳过 ' + s.rejected + ' 个超限文件'
+    if (s.skipped_dup) finalMsg.value += '，' + s.skipped_dup + ' 个已存在（重复）'
     showToast('导入完成')
     emit('imported')
   } else if (s.status === 'cancelled') {

--- a/src/vue-src/components/SimilarImportDialog.vue
+++ b/src/vue-src/components/SimilarImportDialog.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { ref, nextTick } from 'vue'
+import { rememberFocus, restoreFocus, trapTabFocus } from '../utils/api'
+
+interface Candidate {
+  id: number
+  filename: string
+  name: string
+  distance: number
+}
+
+const visible = ref(false)
+const candidates = ref<Candidate[]>([])
+const truncated = ref(false)
+const scanLimit = ref(0)
+const boxEl = ref<HTMLElement>()
+const skipEl = ref<HTMLButtonElement>()
+
+let resolveFn: ((action: string | null) => void) | null = null
+
+async function open(cands: Candidate[], truncatedFlag: boolean = false, limit: number = 0): Promise<string | null> {
+  if (resolveFn) { resolveFn(null); resolveFn = null }
+  candidates.value = cands || []
+  truncated.value = !!truncatedFlag
+  scanLimit.value = limit || 0
+  rememberFocus()
+  visible.value = true
+  await nextTick()
+  // 默认聚焦「跳过」，避免误操作导入/删除
+  skipEl.value?.focus()
+  return new Promise(resolve => { resolveFn = resolve })
+}
+
+function choose(action: string) {
+  visible.value = false
+  restoreFocus()
+  if (resolveFn) { resolveFn(action); resolveFn = null }
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') { e.stopPropagation(); choose('discard') }
+  else if (boxEl.value) trapTabFocus(boxEl.value, e)
+}
+
+function thumbUrl(c: Candidate) {
+  return `/api/thumb/${c.id}/${encodeURIComponent(c.filename)}`
+}
+
+defineExpose({ open })
+</script>
+
+<template>
+  <div v-if="visible" class="similimp-overlay" @click.self="choose('discard')">
+    <div class="similimp-box" ref="boxEl" role="dialog" aria-modal="true" aria-labelledby="similimp-title" @keydown="onKeydown">
+      <div id="similimp-title" class="similimp-title">发现内容近似图片</div>
+      <div class="similimp-desc">这张图与库中的以下图片内容几乎一致，但属于不同的文件。请选择如何处理这次导入。</div>
+      <div v-if="truncated" class="similimp-truncated">注意：表情库较大，本次仅比对了前 {{ scanLimit }} 张，超出上限的图未参与比对。</div>
+      <div class="similimp-cands">
+        <div v-for="c in candidates" :key="c.id" class="similimp-cand">
+          <img :src="thumbUrl(c)" :alt="c.name" class="similimp-thumb" loading="lazy">
+          <div class="similimp-meta">
+            <div class="similimp-name" :title="c.name">{{ c.name }}</div>
+            <div class="similimp-file" :title="c.filename">{{ c.filename }}</div>
+          </div>
+        </div>
+      </div>
+      <div class="similimp-actions">
+        <button class="btn btn-primary" @click="choose('keep_new')">保留新图</button>
+        <button class="btn btn-secondary" @click="choose('keep_old')">保留旧图</button>
+        <button class="btn btn-ghost" @click="choose('keep_both')">都保留</button>
+        <button ref="skipEl" class="btn btn-danger" @click="choose('discard')">跳过</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.similimp-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 260;
+  animation: fadeIn 0.15s ease;
+}
+
+.similimp-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px 24px;
+  width: 400px;
+  max-height: 82vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+}
+
+.similimp-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 6px;
+}
+
+.similimp-desc {
+  font-size: 12px;
+  color: var(--fg-secondary);
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+
+.similimp-truncated {
+  font-size: 11px;
+  color: var(--danger, #ef4444);
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+.similimp-cands {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.similimp-cand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+
+.similimp-thumb {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.similimp-meta {
+  min-width: 0;
+}
+
+.similimp-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.similimp-file {
+  font-size: 11px;
+  color: var(--fg-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.similimp-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+</style>

--- a/src/vue-src/components/SimilarImportDialog.vue
+++ b/src/vue-src/components/SimilarImportDialog.vue
@@ -11,18 +11,14 @@ interface Candidate {
 
 const visible = ref(false)
 const candidates = ref<Candidate[]>([])
-const truncated = ref(false)
-const scanLimit = ref(0)
 const boxEl = ref<HTMLElement>()
 const skipEl = ref<HTMLButtonElement>()
 
 let resolveFn: ((action: string | null) => void) | null = null
 
-async function open(cands: Candidate[], truncatedFlag: boolean = false, limit: number = 0): Promise<string | null> {
+async function open(cands: Candidate[]): Promise<string | null> {
   if (resolveFn) { resolveFn(null); resolveFn = null }
   candidates.value = cands || []
-  truncated.value = !!truncatedFlag
-  scanLimit.value = limit || 0
   rememberFocus()
   visible.value = true
   await nextTick()
@@ -54,7 +50,6 @@ defineExpose({ open })
     <div class="similimp-box" ref="boxEl" role="dialog" aria-modal="true" aria-labelledby="similimp-title" @keydown="onKeydown">
       <div id="similimp-title" class="similimp-title">发现内容近似图片</div>
       <div class="similimp-desc">这张图与库中的以下图片内容几乎一致，但属于不同的文件。请选择如何处理这次导入。</div>
-      <div v-if="truncated" class="similimp-truncated">注意：表情库较大，本次仅比对了前 {{ scanLimit }} 张，超出上限的图未参与比对。</div>
       <div class="similimp-cands">
         <div v-for="c in candidates" :key="c.id" class="similimp-cand">
           <img :src="thumbUrl(c)" :alt="c.name" class="similimp-thumb" loading="lazy">
@@ -108,13 +103,6 @@ defineExpose({ open })
   font-size: 12px;
   color: var(--fg-secondary);
   line-height: 1.6;
-  margin-bottom: 12px;
-}
-
-.similimp-truncated {
-  font-size: 11px;
-  color: var(--danger, #ef4444);
-  line-height: 1.5;
   margin-bottom: 12px;
 }
 

--- a/src/webui.py
+++ b/src/webui.py
@@ -2436,6 +2436,11 @@ def _import_job_worker(webui, files, names, make_collection, folder_name, my_tok
         skipped_dup = r.get("skipped_dup", 0)
         with _IMPORT_JOB_LOCK:
             was_cancel = _IMPORT_JOB_CANCEL
+            is_current = _IMPORT_JOB_STATE.get("token") == my_token
+        if not is_current:
+            # 本任务已不是当前令牌（被新任务取代），立刻返回，
+            # 避免旧 worker 执行 create_collection/add_to_collection 等副作用污染新任务
+            return
         if not was_cancel:
             # 正常完成：进度满格、done 为全部
             _set_import_job_current(

--- a/src/webui.py
+++ b/src/webui.py
@@ -234,6 +234,21 @@ def _find_hotkey_window_position(cursor, work_area, width, height):
     return None
 
 
+def _window_drag_update(win_x, win_y, origin, last_move, dx, dy):
+    """窗口拖动一步计算：返回 (origin, last_move, target)；target 为 None 时无需移动窗口
+
+    - origin 为空：记录拖动起点窗口位置并返回（本次不移动）
+    - 8ms 节流期内：丢弃（不移动）
+    - 否则按起点 + 总偏移移动到绝对目标（自愈，无累积滞后）
+    """
+    now = time.monotonic()
+    if origin is None:
+        return (win_x - dx, win_y - dy), now, None
+    if now - last_move < 0.008:
+        return origin, last_move, None
+    return origin, now, (origin[0] + dx, origin[1] + dy)
+
+
 class JsApi:
     """暴露给前端的 JS API"""
 
@@ -1195,31 +1210,21 @@ class JsApi:
         if not w:
             return
         try:
-            now = time.monotonic()
-            if not self._drag_origin:
-                # 新一轮拖动起点：窗口当前位置 + 前端传来的当帧总偏移
-                self._drag_origin = self._new_drag_origin(w.x, w.y, dx, dy)
-                self._drag_last_move = now
-                return
-            # 8ms 节流丢弃积压的中间消息，主线程只处理最新目标位置
-            if now - self._drag_last_move < 0.008:
-                return
-            self._drag_last_move = now
-            ox, oy = self._drag_origin
-            w.move(ox + dx, oy + dy)
+            origin, last, target = _window_drag_update(
+                w.x, w.y, self._drag_origin, self._drag_last_move, dx, dy
+            )
+            self._drag_origin, self._drag_last_move = origin, last
+            if target:
+                w.move(*target)
         except Exception:
             pass
-
-    def _new_drag_origin(self, wx: int, wy: int, dx: int, dy: int):
-        """记录起点窗口位置（前端传的是自拖start的总偏移，故目标=起点位置）"""
-        return (wx - dx, wy - dy)
 
     def stop_window_drag(self):
         self._drag_origin = None
 
     def start_window_drag(self, button: int, root_x: int, root_y: int) -> bool:
-        self._drag_origin = None
         """Linux 用 GTK begin_move_drag 合成器拖动；其他平台走增量回退"""
+        self._drag_origin = None
         if platform.system() != "Linux":
             return False
         w = self._webui._window
@@ -1451,16 +1456,17 @@ def _storage_migrate_worker(old: Path, new: Path):
         moved = 0
         for src, dst in plan:
             with _STORAGE_MIGRATE_LOCK:
-                if _STORAGE_MIGRATE_STATE["cancel_requested"]:
-                    for s, d in reversed(moved_pairs):
-                        try:
-                            shutil.move(str(d), s)
-                        except OSError:
-                            pass
-                    _set_storage_migrate(
-                        status="cancelled", message="已取消，已回滚已移动文件"
-                    )
-                    return
+                cancel_requested = _STORAGE_MIGRATE_STATE["cancel_requested"]
+            if cancel_requested:
+                for s, d in reversed(moved_pairs):
+                    try:
+                        shutil.move(str(d), s)
+                    except OSError:
+                        pass
+                _set_storage_migrate(
+                    status="cancelled", message="已取消，已回滚已移动文件"
+                )
+                return
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(src, str(dst))
             moved_pairs.append((src, dst))
@@ -1481,7 +1487,7 @@ def _storage_migrate_worker(old: Path, new: Path):
                 webview.windows[0].evaluate_js("refreshMemes();")
         except Exception:
             pass
-    except OSError as e:
+    except Exception as e:
         logger.error("storage migrate error: %s", e)
         # 回滚已移动文件，保持旧目录完整
         for s, d in reversed(moved_pairs):
@@ -1690,17 +1696,12 @@ class SettingsApi:
         if not w:
             return
         try:
-            now = time.monotonic()
-            if not self._drag_origin:
-                self._drag_origin = (w.x - dx, w.y - dy)
-                self._drag_last_move = now
-                return
-            # 8ms 节流丢弃积压的中间消息，主线程只处理最新目标位置
-            if now - self._drag_last_move < 0.008:
-                return
-            self._drag_last_move = now
-            ox, oy = self._drag_origin
-            w.move(ox + dx, oy + dy)
+            origin, last, target = _window_drag_update(
+                w.x, w.y, self._drag_origin, self._drag_last_move, dx, dy
+            )
+            self._drag_origin, self._drag_last_move = origin, last
+            if target:
+                w.move(*target)
         except Exception:
             pass
 
@@ -1708,8 +1709,8 @@ class SettingsApi:
         self._drag_origin = None
 
     def start_window_drag(self, button: int, root_x: int, root_y: int) -> bool:
-        self._drag_origin = None
         """Linux 用 GTK begin_move_drag 合成器拖动；其他平台走增量回退"""
+        self._drag_origin = None
         if platform.system() != "Linux":
             return False
         w = self._webui._settings_window
@@ -2300,7 +2301,6 @@ def _file_sha256(path):
 
 # 感知哈希去重（pHash）：内容近似但 SHA-256 不同时，判定汉明距离阈值
 _PHASH_SIMILAR_DIST = 12  # 64 位感知哈希的汉明距离阈值，≤此值视为近似
-_PHASH_SCAN_LIMIT = 2000  # 全库扫描上限，防止超大库卡顿
 _PHASH_SYNC_BACKFILL_MAX = 5  # 缺失 phash 行数超过此值则后台异步回填，避免阻塞导入
 _PHASH_CACHE = {}  # 文件路径 → (mtime, size, hash)：避免对大库重复全解码
 _PHASH_CACHE_LOCK = threading.Lock()
@@ -2318,7 +2318,9 @@ _IMPORT_JOB_STATE = {
     "total": 0,
     "imported": 0,
     "rejected": 0,
+    "skipped_dup": 0,
     "error": "",
+    "token": None,  # 任务代次：旧 worker 令牌不匹配时不覆盖新任务状态
 }
 _IMPORT_JOB_LOCK = threading.Lock()
 _IMPORT_JOB_CANCEL = False
@@ -2328,6 +2330,15 @@ _ALLOWED_IMPORT_EXT = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
 def _set_import_job(**kw):
     with _IMPORT_JOB_LOCK:
         _IMPORT_JOB_STATE.update(**kw)
+
+
+def _set_import_job_current(my_token, **kw):
+    """仅当 my_token 仍是当前任务令牌时更新状态（旧 worker 在开新任务后不再覆盖）"""
+    with _IMPORT_JOB_LOCK:
+        if _IMPORT_JOB_STATE.get("token") != my_token:
+            return False
+        _IMPORT_JOB_STATE.update(**kw)
+        return True
 
 
 def get_import_progress() -> dict:
@@ -2343,13 +2354,14 @@ def cancel_import_job():
     return {"ok": True}
 
 
-def _import_job_progress_cb(done, total, current):
-    """_do_import 逐文件回调：更新进度；取消时返回 False 中断导入"""
+def _import_job_progress_cb(my_token, done, total, current):
+    """_do_import 逐文件回调：更新进度（仅限当前任务令牌）；取消时返回 False 中断"""
     cancel = False
     with _IMPORT_JOB_LOCK:
         cancel = _IMPORT_JOB_CANCEL
     pct = int(done * 100 / total) if total else 100
-    _set_import_job(
+    _set_import_job_current(
+        my_token,
         progress=pct,
         done=done,
         total=total,
@@ -2360,33 +2372,42 @@ def _import_job_progress_cb(done, total, current):
     return False if cancel else None
 
 
-def _import_job_worker(webui, files, names, make_collection, folder_name):
+def _import_job_worker(webui, files, names, make_collection, folder_name, my_token):
     """后台执行交互式导入（folder/文件对话框/剪贴板），逐文件报进度"""
     global _IMPORT_JOB_CANCEL
     db = get_db()
+
+    def cb(done, total, current):
+        return _import_job_progress_cb(my_token, done, total, current)
+
     try:
         if _IMPORT_JOB_CANCEL:
-            _set_import_job(status="cancelled")
+            _set_import_job_current(my_token, status="cancelled")
             return
-        r = webui._do_import(files, names, _import_job_progress_cb)
+        r = webui._do_import(files, names, cb)
         ids = r.get("ids") or []
         imported = len(ids)
         rejected = r.get("rejected", 0)
+        skipped_dup = r.get("skipped_dup", 0)
         with _IMPORT_JOB_LOCK:
             was_cancel = _IMPORT_JOB_CANCEL
         if not was_cancel:
             # 正常完成：进度满格、done 为全部
-            _set_import_job(
+            _set_import_job_current(
+                my_token,
                 imported=imported,
                 rejected=rejected,
+                skipped_dup=skipped_dup,
                 progress=100,
                 done=len(files),
                 total=len(files),
             )
         else:
             # 取消：保留 progress_cb 已更新的实际 done/total，不强制 100%
-            _set_import_job(imported=imported, rejected=rejected)
-            _set_import_job(status="cancelled", message="导入已取消")
+            _set_import_job_current(
+                my_token, imported=imported, rejected=rejected, skipped_dup=skipped_dup
+            )
+            _set_import_job_current(my_token, status="cancelled", message="导入已取消")
             return
         collection_id = None
         if make_collection and ids and folder_name:
@@ -2397,7 +2418,8 @@ def _import_job_worker(webui, files, names, make_collection, folder_name):
                 from .manifest import build as build_manifest
 
                 build_manifest()
-        _set_import_job(
+        _set_import_job_current(
+            my_token,
             status="done",
             progress=100,
             message="导入完成",
@@ -2405,20 +2427,29 @@ def _import_job_worker(webui, files, names, make_collection, folder_name):
         )
     except Exception as e:
         logger.error("import job error: %s", e)
-        _set_import_job(status="error", error=str(e), message="导入失败")
+        _set_import_job_current(
+            my_token, status="error", error=str(e), message="导入失败"
+        )
     finally:
+        # 仅当仍是当前任务（token 匹配）时才重置取消标志；
+        # 旧 worker 收尾不清新任务的取消标志，保证 token 代次隔离
         with _IMPORT_JOB_LOCK:
-            _IMPORT_JOB_CANCEL = False
+            if _IMPORT_JOB_STATE.get("token") == my_token:
+                _IMPORT_JOB_CANCEL = False
 
 
 def start_import_job(webui, files, names, make_collection=False, folder_name=""):
     """启动后台导入，立即返回；前端轮询 get_import_progress()"""
+    import secrets
+
     global _IMPORT_JOB_CANCEL
     with _IMPORT_JOB_LOCK:
         if _IMPORT_JOB_STATE["status"] == "running":
             return False
+        token = secrets.token_hex(6)
         _IMPORT_JOB_CANCEL = False
         _IMPORT_JOB_STATE.update(
+            token=token,
             status="running",
             progress=0,
             message="开始导入",
@@ -2427,11 +2458,12 @@ def start_import_job(webui, files, names, make_collection=False, folder_name="")
             total=len(files),
             imported=0,
             rejected=0,
+            skipped_dup=0,
             error="",
         )
     threading.Thread(
         target=_import_job_worker,
-        args=(webui, files, names, make_collection, folder_name),
+        args=(webui, files, names, make_collection, folder_name, token),
         daemon=True,
     ).start()
     return True
@@ -2623,8 +2655,8 @@ def _backfill_phash_background(rows, index):
                 phash = _phash_path_cached(fpath)
             except Exception:
                 continue
-            if phash:
-                db.set_perceptual_hash(row["id"], phash)
+            # 无条件写入（set_perceptual_hash 内部处理 0→"0" 占位）
+            db.set_perceptual_hash(row["id"], phash)
     finally:
         with _PHASH_BACKFILL_LOCK:
             _PHASH_BACKFILLING = False
@@ -2653,15 +2685,15 @@ def _ensure_backfill_daemon(rows, index):
 def _find_similar_candidates(img_path):
     """基于 DB 感知哈希的全库比对：只解码新图，存量直接读 DB（微秒级）
 
-    返回 (候选列表, truncated)。phash 为空的旧库行惰性回填（算一次写回 DB）。
+    返回候选列表（全库比对，无截断）。phash 为空的旧库行惰性回填（算一次写回 DB）。
     """
     cfg = get_config()
     db = get_db()
     if not cfg.cache_dir or not HAS_PIL:
-        return [], False
+        return []
     target_hash = _phash_path_cached(img_path)
     if target_hash == 0:
-        return [], False
+        return []
     rows = db.get_all_phash()
     matches = []
     missing = [r for r in rows if not r.get("perceptual_hash")]
@@ -2679,14 +2711,13 @@ def _find_similar_candidates(img_path):
                         ph = _phash_path_cached(fpath)
                     except Exception:
                         ph = 0
-                    if ph:
-                        db.set_perceptual_hash(row["id"], ph)
+                    # 无条件写入（set_perceptual_hash 内部处理 0→"0" 占位）
+                    db.set_perceptual_hash(row["id"], ph)
+                    row["perceptual_hash"] = "0" if ph == 0 else hex(ph)
         else:
             _ensure_backfill_daemon(missing, idx)
     for row in rows:
         fname = row.get("filename")
-        if fname == os.path.basename(img_path):
-            continue
         phash = row.get("perceptual_hash")
         if not phash:
             continue  # 未回填（已交给后台），本次跳过
@@ -2694,6 +2725,8 @@ def _find_similar_candidates(img_path):
             phash = int(phash, 16)
         except (TypeError, ValueError):
             continue
+        if not phash:
+            continue  # 占位 "0"（无感知内容）跳过比较
         dist = _phash_hamming(target_hash, phash)
         if dist <= _PHASH_SIMILAR_DIST:
             matches.append(
@@ -2706,7 +2739,7 @@ def _find_similar_candidates(img_path):
             )
     matches.sort(key=lambda x: x["distance"])
     # DB 比对为微秒级整数运算，全库比对无截断漏检
-    return matches[:5], False
+    return matches[:5]
 
 
 def _prepare_image_import(path) -> dict:
@@ -2733,9 +2766,9 @@ def _prepare_image_import(path) -> dict:
             "hash": fhash,
             "existing_id": row["id"],
         }
-    candidates, truncated = _find_similar_candidates(path)
+    candidates = _find_similar_candidates(path)
     if candidates:
-        return {"status": "similar", "candidates": candidates, "truncated": truncated}
+        return {"status": "similar", "candidates": candidates}
     return {"status": "ok", "hash": fhash}
 
 
@@ -3033,9 +3066,11 @@ class WebUI:
         cache_dir = cfg.cache_dir
         imported = 0
         rejected = 0
+        skipped_dup = 0
         imported_ids = []
         total = len(file_paths)
         done = 0
+        stop_import = False
         for i, src in enumerate(file_paths):
             try:
                 base_name = (
@@ -3076,6 +3111,7 @@ class WebUI:
                     # 去重检查 + 落盘 + 入库 在同一临界区：并发导入同图时不产生重复记录
                     with _IMPORT_LOCK:
                         if db.get_by_hash(fhash):
+                            skipped_dup += 1
                             continue
                         dst = cache_dir / f"{fhash[:16]}{ext}"
                         shutil.copy2(path, dst)
@@ -3100,19 +3136,23 @@ class WebUI:
                         os.unlink(restored)
                     except OSError:
                         pass
+            except Exception as e:
+                logger.error(f"import {src}: {e}")
+            finally:
+                # 每个源文件无论 导入/去重跳过/拒绝/异常 都推进进度并检查取消
                 done += 1
                 if progress_cb:
                     try:
                         if progress_cb(done, total, os.path.basename(src)) is False:
-                            break  # 取消：progress_cb 返回 False 时中断导入
+                            stop_import = True
                     except Exception:
                         pass
-            except Exception as e:
-                logger.error(f"import {src}: {e}")
+            if stop_import:
+                break  # 取消：progress_cb 返回 False 时中断导入
         if imported:
             build_manifest()
         logger.info(f"导入完成: {imported} 个")
-        return {"ids": imported_ids, "rejected": rejected}
+        return {"ids": imported_ids, "rejected": rejected, "skipped_dup": skipped_dup}
 
     def _import_with_similar_decision(self, path, oname=""):
         """单图导入决策：哈希命中提示已存在；内容近似转相似（URL 拖放与文件上传复用）"""
@@ -3126,6 +3166,12 @@ class WebUI:
             ids = r.get("ids") or []
             if ids:
                 return {"ok": True, "id": ids[0]}
+            if r.get("skipped_dup"):
+                return {
+                    "ok": False,
+                    "duplicate": True,
+                    "error": "该图片已存在，无需重复导入",
+                }
             if r.get("rejected"):
                 return {
                     "ok": False,
@@ -3171,8 +3217,6 @@ class WebUI:
             "similar_pending": True,
             "token": token,
             "candidates": cands,
-            "truncated": bool(prep.get("truncated")),
-            "scan_limit": _PHASH_SCAN_LIMIT,
         }
 
     def ensure_import_collection(self, ids, group_name, parent_id=None):

--- a/src/webui.py
+++ b/src/webui.py
@@ -235,12 +235,9 @@ def _find_hotkey_window_position(cursor, work_area, width, height):
 
 
 def _window_drag_update(win_x, win_y, origin, last_move, dx, dy):
-    """窗口拖动一步计算：返回 (origin, last_move, target)；target 为 None 时无需移动窗口
-
-    - origin 为空：记录拖动起点窗口位置并返回（本次不移动）
-    - 8ms 节流期内：丢弃（不移动）
-    - 否则按起点 + 总偏移移动到绝对目标（自愈，无累积滞后）
-    """
+    # 窗口拖动一步计算：返回 (origin, last_move, target)。
+    # origin 为空时记录拖动起点并返回（本次不动）；8ms 节流期内丢弃；
+    # 否则按起点+总偏移移动到绝对目标（自愈，无累积滞后）。
     now = time.monotonic()
     if origin is None:
         return (win_x - dx, win_y - dy), now, None
@@ -881,19 +878,27 @@ class JsApi:
         return self._webui._import_with_similar_decision(path, oname)
 
     def resolve_similar_import(self, token: str, action: str) -> dict:
-        """响应用户对相似图导入的决策：keep_new|keep_both 导入，discard|keep_old 放弃"""
+        """响应用户对相似图导入的决策：
+        discard 丢弃新文件；keep_old 保留旧图且不导入新文件；
+        keep_new 导入新图并替换旧图；keep_both 同时保留并导入两者。
+        """
         item = _pop_pending_similar(token)
         if not item:
             return {"ok": False, "error": "决策已过期，请重新导入"}
         path = item["path"]
         action = action or "keep_new"
         if action in ("discard", "keep_old"):
+            # 丢弃/仅保留旧图：删掉待决策临时文件，不导入
             try:
                 os.unlink(path)
             except OSError:
                 pass
             return {"ok": True, "action": action, "imported": False}
-        # keep_new / keep_both：保留并导入新图（旧图自然继续留在库中）
+        # 取最相似候选（distance 最小）作为"旧图"，用于 keep_new 替换
+        cands = item.get("candidates") or []
+        best_id = (
+            min(cands, key=lambda c: c.get("distance", 99))["id"] if cands else None
+        )
         try:
             r = self._webui._do_import(
                 [path], [item.get("oname")] if item.get("oname") else None
@@ -908,7 +913,23 @@ class JsApi:
                 pass
         ids = r.get("ids") or []
         if ids:
-            return {"ok": True, "id": ids[0], "imported": True}
+            replaced = False
+            if action == "keep_new" and best_id:
+                # keep_new：导入新图并替换旧图（删除最相似旧图）
+                try:
+                    self._db.delete_meme(best_id)
+                    replaced = True  # 以删除成功为准
+                except Exception as e:
+                    logger.error("keep_new 替换旧图失败: %s", e)
+                from .manifest import build as build_manifest
+
+                build_manifest()
+            return {
+                "ok": True,
+                "id": ids[0],
+                "imported": True,
+                "replaced": replaced,
+            }
         if r.get("rejected"):
             return {"ok": False, "error": "文件超过大小/分辨率限制，已跳过"}
         return {"ok": False, "error": "导入失败"}
@@ -1468,7 +1489,36 @@ def _storage_migrate_worker(old: Path, new: Path):
                 )
                 return
             dst.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(src, str(dst))
+            # 排他创建目标（O_EXCL：目标已存在则抛 FileExistsError，
+            # 防 precheck→write 期间并发覆盖既有文件），成功后才删源
+            try:
+                fd = os.open(str(dst), os.O_CREAT | os.O_EXCL, 0o644)
+            except FileExistsError:
+                # 迁移期间目标被其他进程新建：并发冲突，整批回滚并报清晰错误
+                for s, d in reversed(moved_pairs):
+                    try:
+                        shutil.move(str(d), s)
+                    except OSError:
+                        pass
+                _set_storage_migrate(
+                    status="error",
+                    message="迁移失败：目标目录出现同名文件（与进程冲突），已回滚",
+                    error=f"目标已存在: {dst}",
+                )
+                return
+            try:
+                with os.fdopen(fd, "wb") as out_f, open(src, "rb") as in_f:
+                    shutil.copyfileobj(in_f, out_f)
+            except Exception:
+                try:
+                    os.unlink(str(dst))  # 清理复制中途失败留下的半写孤儿目标
+                except OSError:
+                    pass
+                raise
+            try:
+                os.unlink(src)
+            except OSError:
+                pass  # 源删除失败不阻断（目标已排他写入成功）
             moved_pairs.append((src, dst))
             moved += 1
             _set_storage_migrate(

--- a/src/webui.py
+++ b/src/webui.py
@@ -2,6 +2,7 @@
 
 import io
 import logging
+import math
 import os
 import platform
 import socket
@@ -240,6 +241,8 @@ class JsApi:
         self._webui = webui
         self._cfg = get_config()
         self._db = get_db()
+        self._drag_origin = None
+        self._drag_last_move = 0.0
 
     def search_memes(
         self, keyword="", tags=None, collection_id=None, offset=0, limit=200
@@ -792,17 +795,9 @@ class JsApi:
             # Windows 裸路径: C:\Users\...
             local_path = s
         if local_path:
-            r = self._webui._do_import([local_path])
-            ids = r.get("ids") or []
-            if ids:
-                return {"ok": True, "id": ids[0]}
-            if r.get("rejected"):
-                return {
-                    "ok": False,
-                    "rejected": r["rejected"],
-                    "error": "文件超过大小/分辨率限制，已跳过",
-                }
-            return {"ok": False, "error": "导入失败"}
+            return self._import_with_similar_decision(
+                local_path, os.path.basename(local_path)
+            )
 
         clean_url = _strip_url_modifiers(s)
 
@@ -848,17 +843,10 @@ class JsApi:
             # 重命名为正确扩展名
             final_path = tmp_path + ext
             os.rename(tmp_path, final_path)
-            r = self._webui._do_import([final_path])
-            ids = r.get("ids") or []
-            if ids:
-                return {"ok": True, "id": ids[0]}
-            if r.get("rejected"):
-                return {
-                    "ok": False,
-                    "rejected": r["rejected"],
-                    "error": "文件超过大小/分辨率限制，已跳过",
-                }
-            return {"ok": False, "error": "导入失败"}
+            r = self._import_with_similar_decision(
+                final_path, os.path.splitext(os.path.basename(clean_url))[0] or None
+            )
+            return r
         except URLError as e:
             return {"ok": False, "error": f"下载失败: {e.reason}"}
         except Exception as e:
@@ -872,6 +860,43 @@ class JsApi:
                 os.unlink(tmp_path + ext)
             except Exception:
                 pass
+
+    def _import_with_similar_decision(self, path, oname=""):
+        """单图导入决策：哈希命中提示已存在；内容近似转相似（委托 WebUI 统一逻辑）"""
+        return self._webui._import_with_similar_decision(path, oname)
+
+    def resolve_similar_import(self, token: str, action: str) -> dict:
+        """响应用户对相似图导入的决策：keep_new|keep_both 导入，discard|keep_old 放弃"""
+        item = _pop_pending_similar(token)
+        if not item:
+            return {"ok": False, "error": "决策已过期，请重新导入"}
+        path = item["path"]
+        action = action or "keep_new"
+        if action in ("discard", "keep_old"):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            return {"ok": True, "action": action, "imported": False}
+        # keep_new / keep_both：保留并导入新图（旧图自然继续留在库中）
+        try:
+            r = self._webui._do_import(
+                [path], [item.get("oname")] if item.get("oname") else None
+            )
+        except Exception as e:
+            logger.error("resolve similar import error: %s", e)
+            return {"ok": False, "error": "导入失败"}
+        finally:
+            try:
+                os.unlink(path)  # 清理待决策临时文件
+            except OSError:
+                pass
+        ids = r.get("ids") or []
+        if ids:
+            return {"ok": True, "id": ids[0], "imported": True}
+        if r.get("rejected"):
+            return {"ok": False, "error": "文件超过大小/分辨率限制，已跳过"}
+        return {"ok": False, "error": "导入失败"}
 
     def get_sync_progress(self) -> dict:
         return sync_module.get_sync_progress()
@@ -930,7 +955,7 @@ class JsApi:
             return str(e)
 
     def import_memes(self) -> bool:
-        # 通过系统文件对话框选择导入
+        # 通过系统文件对话框选择导入（后台执行，避免大数量导入阻塞界面）
         try:
             result = webview.windows[0].create_file_dialog(
                 webview.FileDialog.OPEN,
@@ -941,12 +966,10 @@ class JsApi:
             return {"ok": False}
         if not result:
             return {"ok": False, "cancelled": True}
-        r = self._webui._do_import(result)
-        return {
-            "ok": True,
-            "imported": len(r.get("ids") or []),
-            "rejected": r.get("rejected", 0),
-        }
+        paths = list(result)
+        if not start_import_job(self._webui, paths, None, False, ""):
+            return {"ok": False, "error": "已有导入在进行中"}
+        return {"ok": True, "async": True}
 
     def import_folder(self, make_collection=True) -> dict:
         """选择文件夹并导入其中全部图片；make_collection 时以文件夹名创建分组"""
@@ -960,41 +983,32 @@ class JsApi:
             return {"ok": False, "cancelled": True}
         folder = result[0] if isinstance(result, (tuple, list)) else result
         try:
-            allowed = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
             files = []
             names = []
             for root, _, fnames in os.walk(folder):
                 for fn in sorted(fnames):
                     ext = os.path.splitext(fn)[1].lower()
-                    if ext not in allowed:
+                    if ext not in _ALLOWED_IMPORT_EXT:
                         continue
                     files.append(os.path.join(root, fn))
                     names.append(os.path.splitext(fn)[0])
             if not files:
                 return {"ok": False, "error": "文件夹中没有支持的图片"}
-            r = self._webui._do_import(files, names)
-            ids = r.get("ids") or []
-            rejected = r.get("rejected", 0)
-            collection_id = None
             folder_name = os.path.basename(os.path.normpath(folder))
-            if make_collection and ids:
-                collection_id = self._db.create_collection(folder_name)
-                if collection_id > 0:
-                    for mid in ids:
-                        self._db.add_to_collection(mid, collection_id)
-                    from .manifest import build as build_manifest
-
-                    build_manifest()
-            return {
-                "ok": True,
-                "imported": len(ids),
-                "rejected": rejected,
-                "collection_id": collection_id,
-                "collection_name": folder_name if make_collection and ids else None,
-            }
+            if not start_import_job(
+                self._webui, files, names, make_collection, folder_name
+            ):
+                return {"ok": False, "error": "已有导入在进行中"}
+            return {"ok": True, "async": True, "total": len(files)}
         except Exception as e:
             logger.error(f"import_folder failed: {e}")
             return {"ok": False, "error": str(e)}
+
+    def get_import_progress(self) -> dict:
+        return get_import_progress()
+
+    def cancel_import_job(self) -> dict:
+        return cancel_import_job()
 
     def import_from_clipboard(self) -> dict:
         import hashlib
@@ -1178,13 +1192,33 @@ class JsApi:
 
     def move_window(self, dx: int, dy: int):
         w = self._webui._window
-        if w:
-            try:
-                w.move(w.x + dx, w.y + dy)
-            except Exception:
-                pass
+        if not w:
+            return
+        try:
+            now = time.monotonic()
+            if not self._drag_origin:
+                # 新一轮拖动起点：窗口当前位置 + 前端传来的当帧总偏移
+                self._drag_origin = self._new_drag_origin(w.x, w.y, dx, dy)
+                self._drag_last_move = now
+                return
+            # 8ms 节流丢弃积压的中间消息，主线程只处理最新目标位置
+            if now - self._drag_last_move < 0.008:
+                return
+            self._drag_last_move = now
+            ox, oy = self._drag_origin
+            w.move(ox + dx, oy + dy)
+        except Exception:
+            pass
+
+    def _new_drag_origin(self, wx: int, wy: int, dx: int, dy: int):
+        """记录起点窗口位置（前端传的是自拖start的总偏移，故目标=起点位置）"""
+        return (wx - dx, wy - dy)
+
+    def stop_window_drag(self):
+        self._drag_origin = None
 
     def start_window_drag(self, button: int, root_x: int, root_y: int) -> bool:
+        self._drag_origin = None
         """Linux 用 GTK begin_move_drag 合成器拖动；其他平台走增量回退"""
         if platform.system() != "Linux":
             return False
@@ -1316,12 +1350,156 @@ def _qqnt_worker(
         _set_qqnt(status="error", message="提取失败", error=str(e))
 
 
+# ─── 存储位置迁移进度（后台线程 + 轮询） ───
+_STORAGE_MIGRATE_STATE = {
+    "status": "idle",  # idle|running|done|error|cancelled
+    "progress": 0,
+    "message": "",
+    "current": "",
+    "moved": 0,
+    "total": 0,
+    "failed": [],
+    "error": "",
+    "cancel_requested": False,
+}
+_STORAGE_MIGRATE_LOCK = threading.Lock()
+_STORAGE_MIGRATE_THREAD = None
+
+
+def _set_storage_migrate(**kw):
+    with _STORAGE_MIGRATE_LOCK:
+        _STORAGE_MIGRATE_STATE.update(**kw)
+
+
+def get_storage_migration_progress() -> dict:
+    import copy
+
+    with _STORAGE_MIGRATE_LOCK:
+        return copy.deepcopy(_STORAGE_MIGRATE_STATE)
+
+
+def cancel_storage_migration():
+    with _STORAGE_MIGRATE_LOCK:
+        if _STORAGE_MIGRATE_STATE["status"] == "running":
+            _STORAGE_MIGRATE_STATE["cancel_requested"] = True
+    return {"ok": True}
+
+
+def start_storage_migration_thread(new_dir: Path):
+    """后台迁移 cache_dir 文件到 new_dir，避免阻塞桥接与 UI"""
+    global _STORAGE_MIGRATE_THREAD
+    old = get_config().cache_dir
+    with _STORAGE_MIGRATE_LOCK:
+        if _STORAGE_MIGRATE_STATE["status"] == "running":
+            return False
+        _STORAGE_MIGRATE_STATE.update(
+            status="running",
+            progress=0,
+            message="准备迁移",
+            current="",
+            moved=0,
+            total=0,
+            failed=[],
+            error="",
+            cancel_requested=False,
+        )
+    _STORAGE_MIGRATE_THREAD = threading.Thread(
+        target=_storage_migrate_worker,
+        args=(old, new_dir),
+        daemon=True,
+    )
+    _STORAGE_MIGRATE_THREAD.start()
+    return True
+
+
+def _storage_migrate_worker(old: Path, new: Path):
+    """两阶段迁移：预检冲突 → 逐文件移动（含取消支持）"""
+    import shutil
+
+    moved_pairs = []
+    try:
+        # 阶段一：扫描 + 预检冲突
+        plan = []
+        for root, dirs, files in os.walk(str(old)):
+            rel = os.path.relpath(root, str(old))
+            for d in list(dirs):
+                if d == "thumbnails":
+                    dirs.remove(d)
+            for name in files:
+                src = os.path.join(root, name)
+                dst = (new if rel == "." else new / rel) / name
+                plan.append((src, dst))
+        total = len(plan)
+        _set_storage_migrate(total=total, message="预检目标目录...")
+        if plan:
+            collisions = [
+                {
+                    "name": os.path.basename(src),
+                    "path": os.path.relpath(src, str(old)),
+                }
+                for src, dst in plan
+                if dst.exists()
+            ]
+            if collisions:
+                _set_storage_migrate(
+                    status="error",
+                    message="目标目录已存在同名文件，未迁移",
+                    error="目标目录已存在 %d 个同名文件" % len(collisions),
+                    failed=[],
+                )
+                return
+        moved = 0
+        for src, dst in plan:
+            with _STORAGE_MIGRATE_LOCK:
+                if _STORAGE_MIGRATE_STATE["cancel_requested"]:
+                    for s, d in reversed(moved_pairs):
+                        try:
+                            shutil.move(str(d), s)
+                        except OSError:
+                            pass
+                    _set_storage_migrate(
+                        status="cancelled", message="已取消，已回滚已移动文件"
+                    )
+                    return
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(src, str(dst))
+            moved_pairs.append((src, dst))
+            moved += 1
+            _set_storage_migrate(
+                progress=int(moved * 100 / total) if total else 100,
+                moved=moved,
+                current=os.path.basename(src),
+            )
+        # 迁移成功后写入新配置（回滚场景不写入，保持旧目录）
+        get_config().set("cache_dir", str(new))
+        get_config().save()
+        _set_storage_migrate(
+            status="done", progress=100, message="迁移完成", current=""
+        )
+        try:
+            if len(webview.windows) > 0:
+                webview.windows[0].evaluate_js("refreshMemes();")
+        except Exception:
+            pass
+    except OSError as e:
+        logger.error("storage migrate error: %s", e)
+        # 回滚已移动文件，保持旧目录完整
+        for s, d in reversed(moved_pairs):
+            try:
+                shutil.move(str(d), s)
+            except OSError:
+                pass
+        _set_storage_migrate(status="error", message="迁移失败", error=str(e))
+
+
 class SettingsApi:
     """暴露给设置窗口的 JS API（仅设置相关方法）"""
 
     def __init__(self, webui):
         self._webui = webui
         self._cfg = get_config()
+        self._drag_origin = None
+        self._drag_last_move = 0.0
 
     def check_connectivity(self) -> dict:
         return _check_connectivity()
@@ -1509,13 +1687,28 @@ class SettingsApi:
 
     def move_window(self, dx: int, dy: int):
         w = self._webui._settings_window
-        if w:
-            try:
-                w.move(w.x + dx, w.y + dy)
-            except Exception:
-                pass
+        if not w:
+            return
+        try:
+            now = time.monotonic()
+            if not self._drag_origin:
+                self._drag_origin = (w.x - dx, w.y - dy)
+                self._drag_last_move = now
+                return
+            # 8ms 节流丢弃积压的中间消息，主线程只处理最新目标位置
+            if now - self._drag_last_move < 0.008:
+                return
+            self._drag_last_move = now
+            ox, oy = self._drag_origin
+            w.move(ox + dx, oy + dy)
+        except Exception:
+            pass
+
+    def stop_window_drag(self):
+        self._drag_origin = None
 
     def start_window_drag(self, button: int, root_x: int, root_y: int) -> bool:
+        self._drag_origin = None
         """Linux 用 GTK begin_move_drag 合成器拖动；其他平台走增量回退"""
         if platform.system() != "Linux":
             return False
@@ -1828,9 +2021,7 @@ class SettingsApi:
         return {"ok": True, "path": path}
 
     def apply_storage_dir(self, path, move_files=False):
-        """应用新的表情包存储目录；move_files=True 时把现有文件迁移过去"""
-        import shutil
-
+        """应用新的表情包存储目录；move_files=True 时后台迁移现有文件"""
         old = self._cfg.cache_dir
         protected = (self._cfg.data_dir, self._cfg.thumbnail_dir)
         ok, err = _storage_dir_validation(path, str(old), protected)
@@ -1843,67 +2034,18 @@ class SettingsApi:
             return {"ok": False, "error": f"创建目录失败: {e}"}
         if not os.access(new, os.W_OK):
             return {"ok": False, "error": "目标目录不可写"}
-        moved, failed = 0, []
-        if move_files:
-            plan = []
-            for root, dirs, files in os.walk(str(old)):
-                rel = os.path.relpath(root, str(old))
-                for d in list(dirs):
-                    if d == "thumbnails":
-                        dirs.remove(d)
-                for name in files:
-                    src = os.path.join(root, name)
-                    dst = (new if rel == "." else new / rel) / name
-                    plan.append((src, dst))
-            if plan:
-                collisions = [
-                    {
-                        "name": os.path.basename(src),
-                        "path": os.path.relpath(src, str(old)),
-                    }
-                    for src, dst in plan
-                    if dst.exists()
-                ]
-                if collisions:
-                    return {
-                        "ok": False,
-                        "error": f"目标目录已存在 {len(collisions)} 个同名文件，未迁移",
-                        "failed": [
-                            {
-                                "name": c["name"],
-                                "path": c["path"],
-                                "error": "目标目录已存在同名文件",
-                            }
-                            for c in collisions
-                        ],
-                    }
-                moved_pairs = []
-                for src, dst in plan:
-                    try:
-                        dst.parent.mkdir(parents=True, exist_ok=True)
-                        shutil.move(src, str(dst))
-                        moved_pairs.append((src, dst))
-                        moved += 1
-                    except OSError as e:
-                        for s, d in reversed(moved_pairs):
-                            try:
-                                shutil.move(str(d), s)
-                            except OSError:
-                                pass
-                        return {
-                            "ok": False,
-                            "error": f"迁移失败（{e}），已回滚已移动文件",
-                            "failed": [
-                                {
-                                    "name": os.path.basename(s),
-                                    "path": os.path.relpath(s, str(old)),
-                                    "error": str(e),
-                                }
-                                for s, _d in moved_pairs
-                            ],
-                        }
-        self._cfg.set("cache_dir", str(new))
-        self._cfg.save()
+        if not move_files:
+            self._cfg.set("cache_dir", str(new))
+            self._cfg.save()
+            self._invalidate_cache_refresh()
+            return {"ok": True, "cache_dir": str(new), "moved": 0, "failed": []}
+        started = start_storage_migration_thread(new)
+        if not started:
+            return {"ok": False, "error": "有迁移任务正在运行"}
+        # 后台迁移进行中，前端轮询 get_storage_migration_progress()
+        return {"ok": True, "async": True, "cache_dir": str(new)}
+
+    def _invalidate_cache_refresh(self):
         fc = getattr(self._webui, "_file_cache", None)
         if fc is not None:
             fc.clear()
@@ -1912,7 +2054,12 @@ class SettingsApi:
                 webview.windows[0].evaluate_js("refreshMemes();")
         except Exception:
             pass
-        return {"ok": True, "cache_dir": str(new), "moved": moved, "failed": failed}
+
+    def get_storage_migration_progress(self) -> dict:
+        return get_storage_migration_progress()
+
+    def cancel_storage_migration(self) -> dict:
+        return cancel_storage_migration()
 
     def qqnt_default_dir(self, base: str, qq_number: str) -> dict:
         """按账号生成默认输出目录（昵称+QQ号）"""
@@ -2149,6 +2296,447 @@ def _file_sha256(path):
         for chunk in iter(lambda: f.read(65536), b""):
             sha.update(chunk)
     return sha.hexdigest()
+
+
+# 感知哈希去重（pHash）：内容近似但 SHA-256 不同时，判定汉明距离阈值
+_PHASH_SIMILAR_DIST = 12  # 64 位感知哈希的汉明距离阈值，≤此值视为近似
+_PHASH_SCAN_LIMIT = 2000  # 全库扫描上限，防止超大库卡顿
+_PHASH_SYNC_BACKFILL_MAX = 5  # 缺失 phash 行数超过此值则后台异步回填，避免阻塞导入
+_PHASH_CACHE = {}  # 文件路径 → (mtime, size, hash)：避免对大库重复全解码
+_PHASH_CACHE_LOCK = threading.Lock()
+_PHASH_BACKFILL_LOCK = threading.Lock()
+_PHASH_BACKFILLING = False  # 当前是否有后台回填线程在跑（防重入）
+_IMPORT_LOCK = threading.Lock()  # 串行化 _do_import 关键区，防并发导入同图重复
+
+# 后台导入进度（文件夹/文件对话框/剪贴板等交互式多文件导入）
+_IMPORT_JOB_STATE = {
+    "status": "idle",  # idle|running|done|error|cancelled
+    "progress": 0,
+    "message": "",
+    "current": "",
+    "done": 0,
+    "total": 0,
+    "imported": 0,
+    "rejected": 0,
+    "error": "",
+}
+_IMPORT_JOB_LOCK = threading.Lock()
+_IMPORT_JOB_CANCEL = False
+_ALLOWED_IMPORT_EXT = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+
+
+def _set_import_job(**kw):
+    with _IMPORT_JOB_LOCK:
+        _IMPORT_JOB_STATE.update(**kw)
+
+
+def get_import_progress() -> dict:
+    with _IMPORT_JOB_LOCK:
+        return dict(_IMPORT_JOB_STATE)
+
+
+def cancel_import_job():
+    global _IMPORT_JOB_CANCEL
+    with _IMPORT_JOB_LOCK:
+        if _IMPORT_JOB_STATE["status"] == "running":
+            _IMPORT_JOB_CANCEL = True
+    return {"ok": True}
+
+
+def _import_job_progress_cb(done, total, current):
+    """_do_import 逐文件回调：更新进度；取消时返回 False 中断导入"""
+    cancel = False
+    with _IMPORT_JOB_LOCK:
+        cancel = _IMPORT_JOB_CANCEL
+    pct = int(done * 100 / total) if total else 100
+    _set_import_job(
+        progress=pct,
+        done=done,
+        total=total,
+        current=current,
+        message=f"导入中 {done}/{total}",
+        status="cancelled" if cancel else "running",
+    )
+    return False if cancel else None
+
+
+def _import_job_worker(webui, files, names, make_collection, folder_name):
+    """后台执行交互式导入（folder/文件对话框/剪贴板），逐文件报进度"""
+    global _IMPORT_JOB_CANCEL
+    db = get_db()
+    try:
+        if _IMPORT_JOB_CANCEL:
+            _set_import_job(status="cancelled")
+            return
+        r = webui._do_import(files, names, _import_job_progress_cb)
+        ids = r.get("ids") or []
+        imported = len(ids)
+        rejected = r.get("rejected", 0)
+        with _IMPORT_JOB_LOCK:
+            was_cancel = _IMPORT_JOB_CANCEL
+        if not was_cancel:
+            # 正常完成：进度满格、done 为全部
+            _set_import_job(
+                imported=imported,
+                rejected=rejected,
+                progress=100,
+                done=len(files),
+                total=len(files),
+            )
+        else:
+            # 取消：保留 progress_cb 已更新的实际 done/total，不强制 100%
+            _set_import_job(imported=imported, rejected=rejected)
+            _set_import_job(status="cancelled", message="导入已取消")
+            return
+        collection_id = None
+        if make_collection and ids and folder_name:
+            collection_id = db.create_collection(folder_name)
+            if collection_id > 0:
+                for mid in ids:
+                    db.add_to_collection(mid, collection_id)
+                from .manifest import build as build_manifest
+
+                build_manifest()
+        _set_import_job(
+            status="done",
+            progress=100,
+            message="导入完成",
+            collection_id=collection_id,
+        )
+    except Exception as e:
+        logger.error("import job error: %s", e)
+        _set_import_job(status="error", error=str(e), message="导入失败")
+    finally:
+        with _IMPORT_JOB_LOCK:
+            _IMPORT_JOB_CANCEL = False
+
+
+def start_import_job(webui, files, names, make_collection=False, folder_name=""):
+    """启动后台导入，立即返回；前端轮询 get_import_progress()"""
+    global _IMPORT_JOB_CANCEL
+    with _IMPORT_JOB_LOCK:
+        if _IMPORT_JOB_STATE["status"] == "running":
+            return False
+        _IMPORT_JOB_CANCEL = False
+        _IMPORT_JOB_STATE.update(
+            status="running",
+            progress=0,
+            message="开始导入",
+            current="",
+            done=0,
+            total=len(files),
+            imported=0,
+            rejected=0,
+            error="",
+        )
+    threading.Thread(
+        target=_import_job_worker,
+        args=(webui, files, names, make_collection, folder_name),
+        daemon=True,
+    ).start()
+    return True
+
+
+# pHash 的一次性 DCT 基（模块加载时预计算，跨图复用）：_PHASH_DCT_COS[k][x]、
+# _PHASH_DCT_NORM[k]（k=0 用 1.0，否则 sqrt(0.5)）
+_PHASH_DCT_COS = [
+    [math.cos((2 * x + 1) * k * math.pi / (2 * 32)) for x in range(32)]
+    for k in range(8)
+]
+_PHASH_DCT_NORM = [1.0 if k == 0 else math.sqrt(0.5) for k in range(8)]
+
+
+def _phash_path_cached(fpath):
+    """带 (mtime, size) 校验的 phash 缓存，文件未变时避免重复解码"""
+    try:
+        st = os.stat(fpath)
+        key = (st.st_mtime, st.st_size)
+    except OSError:
+        return 0
+    with _PHASH_CACHE_LOCK:
+        cached = _PHASH_CACHE.get(fpath)
+        if cached and cached[0] == key:
+            return cached[1]
+    h = _perceptual_hash_path(fpath)
+    if h:
+        with _PHASH_CACHE_LOCK:
+            if len(_PHASH_CACHE) >= 4096:
+                _PHASH_CACHE.clear()  # 简单防膨胀：超过容量整体清空重建
+            _PHASH_CACHE[fpath] = (key, h)
+    return h
+
+
+def _gray_pixels(img):
+    """取 32x32 灰度像素列表（兼容新旧 Pillow：get_flattened_data/getdata）"""
+    from PIL import Image
+
+    small = img.convert("L").resize((32, 32), Image.LANCZOS)
+    getter = getattr(small, "get_flattened_data", None)
+    if getter is not None:
+        return list(getter())
+    return list(small.getdata())
+
+
+def _perceptual_hash(img) -> int:
+    """计算 PIL 图像的 64 位感知哈希（pHash，8x8 可分离 DCT）；比均值哈希判别力更强"""
+    try:
+        px = _gray_pixels(img)
+        rows = [[0.0] * 32 for _ in range(8)]
+        for k in range(8):
+            ck = _PHASH_DCT_COS[k]
+            for x in range(32):
+                ckx = ck[x]
+                row = rows[k]
+                base = x * 32
+                for y in range(32):
+                    row[y] += px[base + y] * ckx
+        dct = [[0.0] * 8 for _ in range(8)]
+        for k in range(8):
+            ck = _PHASH_DCT_NORM[k]
+            for j in range(8):
+                s = 0.0
+                cl = _PHASH_DCT_COS[j]
+                for y in range(32):
+                    s += rows[k][y] * cl[y]
+                dct[k][j] = ck * _PHASH_DCT_NORM[j] * s / 4.0
+        coeffs = [dct[k][j] for k in range(8) for j in range(8)]
+        median = sorted(coeffs)[len(coeffs) // 2]
+        h = 0
+        for i, c in enumerate(coeffs):
+            if c > median:
+                h |= 1 << i
+        return h
+    except Exception:
+        return 0
+
+
+def _perceptual_hash_path(path) -> int:
+    """对图片文件计算感知哈希，失败返回 0（表示不可用）"""
+    if not HAS_PIL:
+        return 0
+    try:
+        with PILImage.open(path) as img:
+            # 动画取首帧
+            if getattr(img, "n_frames", 1) > 1:
+                img.seek(0)
+            return _perceptual_hash(img)
+    except Exception:
+        return 0
+
+
+def _phash_hamming(a: int, b: int) -> int:
+    """两个 64 位哈希的汉明距离"""
+    return bin(a ^ b).count("1")
+
+
+# 等待用户决策的相似图导入项（token → 待导入信息），避免 tmp 被清理
+_PENDING_SIMILAR = {}
+_PENDING_SIMILAR_LOCK = threading.Lock()
+_PENDING_SIMILAR_TTL = 300  # 秒，超时自动丢弃
+
+
+def _register_pending_similar(path: str, oname: str, candidates: list) -> str:
+    import secrets
+
+    token = secrets.token_hex(16)
+    with _PENDING_SIMILAR_LOCK:
+        _PENDING_SIMILAR[token] = {
+            "path": path,
+            "oname": oname,
+            "candidates": candidates,
+            "ts": time.time(),
+        }
+        # 清理过期项
+        now = time.time()
+        for k, v in list(_PENDING_SIMILAR.items()):
+            if now - v["ts"] > _PENDING_SIMILAR_TTL:
+                try:
+                    os.unlink(v["path"])
+                except OSError:
+                    pass
+                del _PENDING_SIMILAR[k]
+    return token
+
+
+def _pop_pending_similar(token: str) -> dict:
+    with _PENDING_SIMILAR_LOCK:
+        item = _PENDING_SIMILAR.pop(token, None)
+        if item and time.time() - item.get("ts", 0) > _PENDING_SIMILAR_TTL:
+            # 已过期：删除临时文件并视为不存在
+            try:
+                os.unlink(item["path"])
+            except OSError:
+                pass
+            item = None
+    return item
+
+
+def _iter_cache_images(cache_dir):
+    """遍历缓存目录下所有在库图片的 (filename, fullpath)，跳过 thumbnails 与子目录"""
+    try:
+        for root, dirs, files in os.walk(str(cache_dir)):
+            for d in list(dirs):
+                if d == "thumbnails":
+                    dirs.remove(d)
+            for name in files:
+                if _detect_image_ext(os.path.join(root, name)):
+                    yield name, os.path.join(root, name)
+    except OSError:
+        return
+
+
+def _build_cache_index():
+    """一次性构建 库中 filename → 绝对路径 映射（供批量回填，避免逐行 walk）"""
+    idx = {}
+    cfg = get_config()
+    for fname, fpath in _iter_cache_images(Path(str(cfg.cache_dir))):
+        idx[fname] = fpath
+    return idx
+
+
+def _resolve_cache_file(filename, index=None):
+    """根据 DB 中的 filename 定位缓存文件绝对路径（一级优先，退化用 index/遍历）"""
+    if index is not None:
+        return index.get(filename) or ""
+    cfg = get_config()
+    cache_dir = cfg.cache_dir
+    direct = cache_dir / filename
+    if direct.is_file():
+        return str(direct)
+    for _fname, fpath in _iter_cache_images(Path(str(cache_dir))):
+        if _fname == filename:
+            return fpath
+    return ""
+
+
+def _backfill_phash_background(rows, index):
+    """后台线程：为 phash 为空的旧库行补算并写回 DB（不阻塞导入）"""
+    global _PHASH_BACKFILLING
+    db = get_db()
+    try:
+        for row in rows:
+            fname = row.get("filename")
+            fpath = index.get(fname) if index else _resolve_cache_file(fname)
+            if not fpath:
+                continue
+            try:
+                phash = _phash_path_cached(fpath)
+            except Exception:
+                continue
+            if phash:
+                db.set_perceptual_hash(row["id"], phash)
+    finally:
+        with _PHASH_BACKFILL_LOCK:
+            _PHASH_BACKFILLING = False
+
+
+def _ensure_backfill_daemon(rows, index):
+    """若当前无后台回填在跑，启动一个（防重入）；已跑则跳过"""
+    global _PHASH_BACKFILLING
+    if not rows:
+        return
+    with _PHASH_BACKFILL_LOCK:
+        if _PHASH_BACKFILLING:
+            return
+        _PHASH_BACKFILLING = True
+    try:
+        threading.Thread(
+            target=_backfill_phash_background,
+            args=(rows, index),
+            daemon=True,
+        ).start()
+    except Exception:
+        with _PHASH_BACKFILL_LOCK:
+            _PHASH_BACKFILLING = False
+
+
+def _find_similar_candidates(img_path):
+    """基于 DB 感知哈希的全库比对：只解码新图，存量直接读 DB（微秒级）
+
+    返回 (候选列表, truncated)。phash 为空的旧库行惰性回填（算一次写回 DB）。
+    """
+    cfg = get_config()
+    db = get_db()
+    if not cfg.cache_dir or not HAS_PIL:
+        return [], False
+    target_hash = _phash_path_cached(img_path)
+    if target_hash == 0:
+        return [], False
+    rows = db.get_all_phash()
+    matches = []
+    missing = [r for r in rows if not r.get("perceptual_hash")]
+    # 缺失行少：同步回填；缺失多：后台回填，本次只比对已填的（无缺失则不遍历目录）
+    if missing:
+        try:
+            idx = _build_cache_index()
+        except Exception:
+            idx = {}
+        if len(missing) <= _PHASH_SYNC_BACKFILL_MAX:
+            for row in missing:
+                fpath = idx.get(row.get("filename")) or ""
+                if fpath:
+                    try:
+                        ph = _phash_path_cached(fpath)
+                    except Exception:
+                        ph = 0
+                    if ph:
+                        db.set_perceptual_hash(row["id"], ph)
+        else:
+            _ensure_backfill_daemon(missing, idx)
+    for row in rows:
+        fname = row.get("filename")
+        if fname == os.path.basename(img_path):
+            continue
+        phash = row.get("perceptual_hash")
+        if not phash:
+            continue  # 未回填（已交给后台），本次跳过
+        try:
+            phash = int(phash, 16)
+        except (TypeError, ValueError):
+            continue
+        dist = _phash_hamming(target_hash, phash)
+        if dist <= _PHASH_SIMILAR_DIST:
+            matches.append(
+                {
+                    "id": row["id"],
+                    "filename": fname,
+                    "name": row.get("original_name") or fname,
+                    "distance": dist,
+                }
+            )
+    matches.sort(key=lambda x: x["distance"])
+    # DB 比对为微秒级整数运算，全库比对无截断漏检
+    return matches[:5], False
+
+
+def _prepare_image_import(path) -> dict:
+    """单图导入前的去重决策：返回 hash_dup / similar / ok / rejected"""
+    db = get_db()
+    w = h = 0
+    try:
+        fsize = os.path.getsize(path)
+    except OSError:
+        fsize = 0
+    if HAS_PIL:
+        try:
+            with PILImage.open(path) as img:
+                w, h = img.size
+        except Exception:
+            pass
+    if fsize > _IMPORT_MAX_BYTES or max(w, h) > _IMPORT_MAX_PX:
+        return {"status": "rejected", "error": "文件超过大小/分辨率限制，已跳过"}
+    fhash = _file_sha256(path)
+    row = db.get_by_hash(fhash)
+    if row:
+        return {
+            "status": "hash_dup",
+            "hash": fhash,
+            "existing_id": row["id"],
+        }
+    candidates, truncated = _find_similar_candidates(path)
+    if candidates:
+        return {"status": "similar", "candidates": candidates, "truncated": truncated}
+    return {"status": "ok", "hash": fhash}
 
 
 def _detect_image_ext(path):
@@ -2437,7 +3025,7 @@ class WebUI:
                 return full
         return ""
 
-    def _do_import(self, file_paths, names=None):
+    def _do_import(self, file_paths, names=None, progress_cb=None):
         import shutil
 
         cfg = get_config()
@@ -2446,6 +3034,8 @@ class WebUI:
         imported = 0
         rejected = 0
         imported_ids = []
+        total = len(file_paths)
+        done = 0
         for i, src in enumerate(file_paths):
             try:
                 base_name = (
@@ -2480,30 +3070,42 @@ class WebUI:
                         )
                         continue
                     fhash = _file_sha256(path)
-                    if db.get_by_hash(fhash):
-                        continue
                     ext = _detect_image_ext(path) or os.path.splitext(path)[1] or ".png"
-                    dst = cache_dir / f"{fhash[:16]}{ext}"
-                    shutil.copy2(path, dst)
-                    db.add_meme(
-                        filename=dst.name,
-                        file_hash=fhash,
-                        width=w,
-                        height=h,
-                        file_size=fsize,
-                        mime_type=f"image/{ext[1:]}" if ext else "image/png",
-                        original_name=oname,
-                        stego_of_hash=stego_of_hash,
-                        from_stego=from_stego,
-                    )
-                    row = db.get_by_hash(fhash)
-                    if row:
-                        imported_ids.append(row["id"])
-                    imported += 1
+                    # 感知哈希计算较重（解码+DCT），放锁外避免持锁阻塞其他导入
+                    src_phash = _perceptual_hash_path(path)
+                    # 去重检查 + 落盘 + 入库 在同一临界区：并发导入同图时不产生重复记录
+                    with _IMPORT_LOCK:
+                        if db.get_by_hash(fhash):
+                            continue
+                        dst = cache_dir / f"{fhash[:16]}{ext}"
+                        shutil.copy2(path, dst)
+                        db.add_meme(
+                            filename=dst.name,
+                            file_hash=fhash,
+                            width=w,
+                            height=h,
+                            file_size=fsize,
+                            mime_type=f"image/{ext[1:]}" if ext else "image/png",
+                            original_name=oname,
+                            stego_of_hash=stego_of_hash,
+                            from_stego=from_stego,
+                            perceptual_hash=src_phash,
+                        )
+                        row = db.get_by_hash(fhash)
+                        if row:
+                            imported_ids.append(row["id"])
+                        imported += 1
                 if restored:
                     try:
                         os.unlink(restored)
                     except OSError:
+                        pass
+                done += 1
+                if progress_cb:
+                    try:
+                        if progress_cb(done, total, os.path.basename(src)) is False:
+                            break  # 取消：progress_cb 返回 False 时中断导入
+                    except Exception:
                         pass
             except Exception as e:
                 logger.error(f"import {src}: {e}")
@@ -2511,6 +3113,81 @@ class WebUI:
             build_manifest()
         logger.info(f"导入完成: {imported} 个")
         return {"ids": imported_ids, "rejected": rejected}
+
+    def _import_with_similar_decision(self, path, oname=""):
+        """单图导入决策：哈希命中提示已存在；内容近似转相似（URL 拖放与文件上传复用）"""
+        try:
+            prep = _prepare_image_import(path)
+        except Exception as e:
+            logger.error("import decision error: %s", e)
+            return {"ok": False, "error": "导入失败"}
+        if prep.get("status") == "ok":
+            r = self._do_import([path], [oname] if oname else None)
+            ids = r.get("ids") or []
+            if ids:
+                return {"ok": True, "id": ids[0]}
+            if r.get("rejected"):
+                return {
+                    "ok": False,
+                    "rejected": r["rejected"],
+                    "error": "文件超过大小/分辨率限制，已跳过",
+                }
+            return {"ok": False, "error": "导入失败"}
+        if prep.get("status") == "rejected":
+            return {
+                "ok": False,
+                "rejected": 1,
+                "error": prep.get("error") or "导入失败",
+            }
+        if prep.get("status") == "hash_dup":
+            return {
+                "ok": False,
+                "duplicate": True,
+                "existing_id": prep.get("existing_id", 0),
+                "error": "该图片已存在，无需重复导入",
+            }
+        # similar：先把文件复制到独立临时目录，避免调用方 finally 清理源文件
+        import tempfile
+
+        cands = prep.get("candidates") or []
+        hold = None
+        try:
+            ext = os.path.splitext(path)[1] or ".png"
+            fd, hold = tempfile.mkstemp(prefix="ohmm_simil_", suffix=ext)
+            os.close(fd)
+            import shutil
+
+            shutil.copy2(path, hold)
+        except OSError:
+            if hold:
+                try:
+                    os.unlink(hold)
+                except OSError:
+                    pass
+            return {"ok": False, "error": "导入失败"}
+        token = _register_pending_similar(hold, oname, cands)
+        return {
+            "ok": False,
+            "similar_pending": True,
+            "token": token,
+            "candidates": cands,
+            "truncated": bool(prep.get("truncated")),
+            "scan_limit": _PHASH_SCAN_LIMIT,
+        }
+
+    def ensure_import_collection(self, ids, group_name, parent_id=None):
+        """把导入 ids 加入固定名分组（同名复用，不存在则建）；返回 collection_id"""
+        if not ids or not group_name:
+            return -1
+        db = get_db()
+        cid = db.create_collection(group_name, parent_id=parent_id)
+        if cid > 0:
+            for mid in ids:
+                db.add_to_collection(mid, cid)
+            from .manifest import build as build_manifest
+
+            build_manifest()
+        return cid
 
     def _on_hotkey_change(self, new_hotkey: str):
         if self._on_hotkey_change_cb:
@@ -2638,6 +3315,17 @@ class WebUI:
                     base = os.path.splitext(oname)[0]
                     names.append(base)
                 if paths:
+                    if len(paths) == 1:
+                        # 单张上传走相似/哈希决策，能触发重复与近似检测
+                        r = self._import_with_similar_decision(
+                            paths[0], names[0] if names else ""
+                        )
+                        for p in paths:
+                            try:
+                                os.unlink(p)
+                            except Exception:
+                                pass
+                        return r
                     self._do_import(paths, names)
                     for p in paths:
                         try:
@@ -2725,6 +3413,7 @@ class WebUI:
                         file_size=fsize,
                         mime_type=mime,
                         original_name=oname,
+                        perceptual_hash=_perceptual_hash_path(fpath),
                     )
                     added += 1
                 except Exception as e:

--- a/src/webui.py
+++ b/src/webui.py
@@ -878,10 +878,7 @@ class JsApi:
         return self._webui._import_with_similar_decision(path, oname)
 
     def resolve_similar_import(self, token: str, action: str) -> dict:
-        """响应用户对相似图导入的决策：
-        discard 丢弃新文件；keep_old 保留旧图且不导入新文件；
-        keep_new 导入新图并替换旧图；keep_both 同时保留并导入两者。
-        """
+        """响应用户对相似图的导入决策（action: discard/keep_old/keep_new/keep_both）"""
         item = _pop_pending_similar(token)
         if not item:
             return {"ok": False, "error": "决策已过期，请重新导入"}
@@ -915,15 +912,11 @@ class JsApi:
         if ids:
             replaced = False
             if action == "keep_new" and best_id:
-                # keep_new：导入新图并替换旧图（删除最相似旧图）
+                # keep_new：导入新图并替换旧图——完整删除链（文件+缩略图+缓存+DB）
                 try:
-                    self._db.delete_meme(best_id)
-                    replaced = True  # 以删除成功为准
+                    replaced = self.delete_meme(best_id)
                 except Exception as e:
                     logger.error("keep_new 替换旧图失败: %s", e)
-                from .manifest import build as build_manifest
-
-                build_manifest()
             return {
                 "ok": True,
                 "id": ids[0],
@@ -1040,10 +1033,12 @@ class JsApi:
             logger.error(f"import_folder failed: {e}")
             return {"ok": False, "error": str(e)}
 
-    def get_import_progress(self) -> dict:
+    def get_import_progress(self):
+        # 后台导入进度快照（前端轮询用）
         return get_import_progress()
 
-    def cancel_import_job(self) -> dict:
+    def cancel_import_job(self):
+        # 请求取消当前后台导入
         return cancel_import_job()
 
     def import_from_clipboard(self) -> dict:
@@ -1490,9 +1485,9 @@ def _storage_migrate_worker(old: Path, new: Path):
                 return
             dst.parent.mkdir(parents=True, exist_ok=True)
             # 排他创建目标（O_EXCL：目标已存在则抛 FileExistsError，
-            # 防 precheck→write 期间并发覆盖既有文件），成功后才删源
+            # 防 precheck→write 期间并发覆盖既有文件），O_WRONLY 确保 fd 可写
             try:
-                fd = os.open(str(dst), os.O_CREAT | os.O_EXCL, 0o644)
+                fd = os.open(str(dst), os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o644)
             except FileExistsError:
                 # 迁移期间目标被其他进程新建：并发冲突，整批回滚并报清晰错误
                 for s, d in reversed(moved_pairs):

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -1646,6 +1646,11 @@ function toggleSidebar() {
       try {
         const r = await api('download_original_image', uri);
         if (r && r.ok) { location.reload(); return; }
+        if (r && r.similar_pending) {
+          showToast('该图片与库中已有图片内容近似，请在“拖拽排序关闭”的主界面重新导入以选择处理');
+          return;
+        }
+        if (r && r.error) showToast(r.error);
       } catch(_) {}
     }
     if (file) {
@@ -1674,18 +1679,30 @@ titlebar.addEventListener('mousedown', async (e) => {
   if (e.target.closest('.title-btn') || e.target.closest('.icon-btn')) return;
   const nativeDrag = await api('start_window_drag', e.button + 1, e.screenX, e.screenY);
   if (nativeDrag) return;   // Linux：交给合成器拖动
-  dragState = { sx: e.screenX, sy: e.screenY };
+  dragState = { sx: e.screenX, sy: e.screenY, px: 0, py: 0, raf: null };
   e.preventDefault();
 });
 document.addEventListener('mousemove', (e) => {
   if (!dragState) return;
-  const dx = e.screenX - dragState.sx, dy = e.screenY - dragState.sy;
-  if (dx !== 0 || dy !== 0) {
-    api('move_window', dx, dy);
-    dragState.sx = e.screenX; dragState.sy = e.screenY;
-  }
+  // 记录相对拖动起点的总偏移（屏幕坐标，自愈无累积滞后）
+  dragState.px = e.screenX - dragState.sx;
+  dragState.py = e.screenY - dragState.sy;
+  // rAF 合并每帧最新位置，避免高回报率鼠标消息风暴堵塞桥接
+  if (dragState.raf) return;
+  dragState.raf = requestAnimationFrame(() => {
+    if (!dragState) return;
+    dragState.raf = null;
+    const dx = dragState.px, dy = dragState.py;
+    if (dx !== 0 || dy !== 0) {
+      api('move_window', dx, dy);
+    }
+  });
 });
-document.addEventListener('mouseup', () => { dragState = null; });
+document.addEventListener('mouseup', () => {
+  if (dragState && dragState.raf) cancelAnimationFrame(dragState.raf);
+  api('stop_window_drag').catch(() => {});
+  dragState = null;
+});
 
 async function checkUpdateAndPrompt() {
   try {

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -423,7 +423,7 @@
       <span id="storage-migrate-count" style="margin-left:12px"></span>
     </div>
     <button id="btn-storage-migrate-cancel" class="btn btn-ghost btn-sm" onclick="cancelStorageMigration()">取消</button>
-    <button id="btn-storage-migrate-bg" class="btn btn-secondary btn-sm" onclick="hideStorageMigration()">后台运行</button>
+    <button id="btn-storage-migrate-bg" class="btn btn-secondary btn-sm" onclick="hideStorageMigration(true, false)">后台运行</button>
   </div>
 </div>
 

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -411,6 +411,22 @@
   </div>
 </div>
 
+<div id="storage-migrate-overlay" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);align-items:center;justify-content:center;z-index:400;animation:fadeIn .15s">
+  <div style="background:var(--surface);border-radius:var(--radius-lg);padding:24px 28px;width:420px;border:1px solid var(--border);box-shadow:var(--shadow-lg);text-align:center">
+    <div style="font-size:14px;font-weight:600;color:var(--fg);margin-bottom:4px" id="storage-migrate-title">正在迁移表情包...</div>
+    <div style="font-size:12px;color:var(--fg-secondary);margin-bottom:12px;word-break:break-all" id="storage-migrate-file">准备中</div>
+    <div style="width:100%;height:8px;background:var(--bg);border-radius:4px;overflow:hidden;margin-bottom:6px">
+      <div id="storage-migrate-bar" style="width:0%;height:100%;background:var(--accent);border-radius:4px;transition:width .3s"></div>
+    </div>
+    <div style="font-size:11.5px;color:var(--muted);margin-bottom:16px">
+      <span id="storage-migrate-pct">0%</span>
+      <span id="storage-migrate-count" style="margin-left:12px"></span>
+    </div>
+    <button id="btn-storage-migrate-cancel" class="btn btn-ghost btn-sm" onclick="cancelStorageMigration()">取消</button>
+    <button id="btn-storage-migrate-bg" class="btn btn-secondary btn-sm" onclick="hideStorageMigration()">后台运行</button>
+  </div>
+</div>
+
 <div id="sync-done-overlay" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);align-items:center;justify-content:center;z-index:400;animation:fadeIn .15s">
   <div style="background:var(--surface);border-radius:var(--radius-lg);padding:24px 28px;width:380px;border:1px solid var(--border);box-shadow:var(--shadow-lg);text-align:center">
     <div style="font-size:14px;font-weight:600;color:var(--fg);margin-bottom:8px" id="sync-done-title">同步完成</div>

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -66,7 +66,7 @@ function trapSettingsFocus(box, e) {
   }
 }
 // 找当前可见覆盖层（静态 HTML + 动态创建的 update/confirm 弹窗）
-const _SETTINGS_OVERLAY_IDS = ['danger-overlay','sync-progress-overlay','sync-done-overlay','qq-import-overlay','qqnt-overlay','tg-import-overlay','dy-import-overlay','wechat-import-overlay','update-overlay'];
+const _SETTINGS_OVERLAY_IDS = ['danger-overlay','sync-progress-overlay','sync-done-overlay','storage-migrate-overlay','qq-import-overlay','qqnt-overlay','tg-import-overlay','dy-import-overlay','wechat-import-overlay','update-overlay'];
 function visibleSettingsOverlay() {
   for (const id of _SETTINGS_OVERLAY_IDS) {
     const el = document.getElementById(id);
@@ -403,6 +403,7 @@ function cancelStoragePick() {
   loadStorageInfo();
 }
 
+let storageMigrateTimer = null;
 async function applyStorageDir() {
   if (!pendingStorageDir) return;
   const moveEl = document.getElementById('s-move-files');
@@ -419,6 +420,11 @@ async function applyStorageDir() {
     }
     pendingStorageDir = null;
     if (pending) pending.style.display = 'none';
+    if (move && r.async) {
+      // 后台迁移：弹出进度覆盖层轮询
+      showStorageMigration();
+      return;
+    }
     const el = document.getElementById('s-cache-dir');
     if (el && r.cache_dir) el.value = r.cache_dir;
     let msg = '已应用新存储目录';
@@ -431,6 +437,65 @@ async function applyStorageDir() {
   } finally {
     if (btn) btn.disabled = false;
   }
+}
+
+function showStorageMigration() {
+  document.getElementById('storage-migrate-title').textContent = '正在迁移表情包...';
+  document.getElementById('storage-migrate-file').textContent = '准备中';
+  document.getElementById('storage-migrate-bar').style.width = '0%';
+  document.getElementById('storage-migrate-pct').textContent = '0%';
+  document.getElementById('storage-migrate-count').textContent = '';
+  const cancelBtn = document.getElementById('btn-storage-migrate-cancel');
+  if (cancelBtn) { cancelBtn.style.display = 'inline-block'; cancelBtn.disabled = false; }
+  rememberSettingsFocus();
+  document.getElementById('storage-migrate-overlay').style.display = 'flex';
+  if (storageMigrateTimer) clearInterval(storageMigrateTimer);
+  storageMigrateTimer = setInterval(pollStorageMigration, 300);
+  pollStorageMigration();
+}
+
+function hideStorageMigration(restore = true) {
+  if (storageMigrateTimer) { clearInterval(storageMigrateTimer); storageMigrateTimer = null; }
+  document.getElementById('storage-migrate-overlay').style.display = 'none';
+  if (restore) restoreSettingsFocus();
+}
+
+async function pollStorageMigration() {
+  let s = null;
+  try { s = await api('get_storage_migration_progress'); } catch (e) { s = null; }
+  if (!s) return;
+  const bar = document.getElementById('storage-migrate-bar');
+  const pct = document.getElementById('storage-migrate-pct');
+  const file = document.getElementById('storage-migrate-file');
+  const count = document.getElementById('storage-migrate-count');
+  if (bar) bar.style.width = (s.progress || 0) + '%';
+  if (pct) pct.textContent = (s.progress || 0) + '%';
+  if (file) file.textContent = s.current || s.message || '';
+  if (count) count.textContent = s.total > 0 ? ('已迁移 ' + (s.moved || 0) + ' / ' + s.total + ' 个') : '';
+  if (!s.status || s.status === 'idle' || s.status === 'running') return;
+  // 结束状态：done/error/cancelled
+  hideStorageMigration(false);
+  const status = document.getElementById('s-storage-status');
+  if (s.status === 'done') {
+    if (status) status.textContent = '迁移完成，新存储目录已生效（' + (s.total || 0) + ' 个文件）';
+    showToast('存储位置已更新');
+    location.reload();
+  } else if (s.status === 'cancelled') {
+    if (status) status.textContent = '迁移已取消，已回滚已移动文件（原存储目录未变）';
+    showToast('已取消迁移');
+  } else {
+    if (status) status.textContent = '迁移失败：' + (s.error || '未知错误') + '（已回滚，原存储目录未变）';
+    showToast('迁移失败');
+  }
+}
+
+function cancelStorageMigration() {
+  const btn = document.getElementById('btn-storage-migrate-cancel');
+  if (btn) btn.disabled = true;
+  const title = document.getElementById('storage-migrate-title');
+  if (title) title.textContent = '正在取消...';
+  api('cancel_storage_migration').catch(() => {});
+  // overlay 由 pollStorageMigration 收到 cancelled 后自动关闭
 }
 
 function toggleSyncType() {
@@ -1701,18 +1766,30 @@ titlebar.addEventListener('mousedown', async (e) => {
   if (e.target.closest('.title-btn')) return;
   const nativeDrag = await api('start_window_drag', e.button + 1, e.screenX, e.screenY);
   if (nativeDrag) return;   // Linux：交给合成器拖动
-  dragState = { sx: e.screenX, sy: e.screenY };
+  dragState = { sx: e.screenX, sy: e.screenY, px: 0, py: 0, raf: null };
   e.preventDefault();
 });
 document.addEventListener('mousemove', (e) => {
   if (!dragState) return;
-  const dx = e.screenX - dragState.sx, dy = e.screenY - dragState.sy;
-  if (dx !== 0 || dy !== 0) {
-    api('move_window', dx, dy);
-    dragState.sx = e.screenX; dragState.sy = e.screenY;
-  }
+  // 记录相对拖动起点的总偏移（屏幕坐标，自愈无累积滞后）
+  dragState.px = e.screenX - dragState.sx;
+  dragState.py = e.screenY - dragState.sy;
+  // rAF 合并每帧最新位置，避免高回报率鼠标消息风暴堵塞桥接
+  if (dragState.raf) return;
+  dragState.raf = requestAnimationFrame(() => {
+    if (!dragState) return;
+    dragState.raf = null;
+    const dx = dragState.px, dy = dragState.py;
+    if (dx !== 0 || dy !== 0) {
+      api('move_window', dx, dy);
+    }
+  });
 });
-document.addEventListener('mouseup', () => { dragState = null; });
+document.addEventListener('mouseup', () => {
+  if (dragState && dragState.raf) cancelAnimationFrame(dragState.raf);
+  api('stop_window_drag').catch(() => {});
+  dragState = null;
+});
 
 /* Keyboard shortcuts */
 document.addEventListener('keydown', (e) => {
@@ -1760,6 +1837,11 @@ document.addEventListener('keydown', (e) => {
     if (syncDoneOverlay && syncDoneOverlay.style.display === 'flex') {
       syncDoneOverlay.style.display = 'none';
       restoreSettingsFocus();
+      return;
+    }
+    const migrateOverlay = document.getElementById('storage-migrate-overlay');
+    if (migrateOverlay && migrateOverlay.style.display === 'flex') {
+      cancelStorageMigration();
       return;
     }
     closeSettings();

--- a/src/webui/settings.js
+++ b/src/webui/settings.js
@@ -454,8 +454,10 @@ function showStorageMigration() {
   pollStorageMigration();
 }
 
-function hideStorageMigration(restore = true) {
-  if (storageMigrateTimer) { clearInterval(storageMigrateTimer); storageMigrateTimer = null; }
+function hideStorageMigration(restore = true, clearTimer = true) {
+  // 后台运行时保留轮询（clearTimer=false），使完成/失败/取消状态仍可被观察到；
+  // 终态关闭才清 timer
+  if (clearTimer && storageMigrateTimer) { clearInterval(storageMigrateTimer); storageMigrateTimer = null; }
   document.getElementById('storage-migrate-overlay').style.display = 'none';
   if (restore) restoreSettingsFocus();
 }

--- a/src/wechat_probe.py
+++ b/src/wechat_probe.py
@@ -951,8 +951,10 @@ def _wechat_worker(webui, user_root, download, account_path):
             imported = len(result.get("ids", []))
             rejected = result.get("rejected", 0)
             if imported:
-                # 自动归入「微信」分组（同名复用）
-                webui.ensure_import_collection(result.get("ids", []), "微信")
+                try:
+                    webui.ensure_import_collection(result.get("ids", []), "微信")
+                except Exception as e:
+                    logger.error("wechat 自动分组失败: %s", e)
         else:
             imported = 0
             rejected = 0

--- a/src/wechat_probe.py
+++ b/src/wechat_probe.py
@@ -950,6 +950,9 @@ def _wechat_worker(webui, user_root, download, account_path):
             result = webui._do_import(imported_paths)
             imported = len(result.get("ids", []))
             rejected = result.get("rejected", 0)
+            if imported:
+                # 自动归入「微信」分组（同名复用）
+                webui.ensure_import_collection(result.get("ids", []), "微信")
         else:
             imported = 0
             rejected = 0

--- a/tests/test_import_concurrency.py
+++ b/tests/test_import_concurrency.py
@@ -1,0 +1,124 @@
+"""# _do_import 并发去重测试
+
+核心保障：并发导入同一字节图只产生 1 条记录；不同图并发都能入库。
+说明：隔离 DB 与 cache_dir，`WebUI` 实例可安全构造（test_startup 已验证不启 GUI）。
+"""
+
+import concurrent.futures
+import shutil
+
+import pytest
+from PIL import Image
+
+from src import webui
+from src.database import MemeDB
+
+
+class _IsoCfg:
+    """隔离 config：仅暴露 _do_import 用到的 cache_dir 等"""
+
+    def __init__(self, cache_dir):
+        self.cache_dir = cache_dir
+        self.data_dir = cache_dir.parent / "data"
+        self.thumbnail_dir = cache_dir.parent / "thumbs"
+
+    def get(self, key, default=None):
+        return default
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    """隔离 DB/cache 并 patch 模块级 get_db/get_config，返回 (db, cache_dir, WebUI)"""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    db = MemeDB(tmp_path / "test.db")
+    cfg = _IsoCfg(cache_dir)
+    monkeypatch.setattr(webui, "get_db", lambda: db)
+    monkeypatch.setattr(webui, "get_config", lambda: cfg)
+    # _do_import 成功路径会调 build_manifest；manifest 单独导入 config/database，
+    # 需在 manifest 命名空间也 patch，否则会读写真实 data_dir
+    import src.manifest as _manifest
+
+    monkeypatch.setattr(_manifest, "get_db", lambda: db)
+    monkeypatch.setattr(_manifest, "get_config", lambda: cfg)
+    ui = webui.WebUI()
+    ui._cfg = None  # 隔离模式下不依赖真实 cfg（_do_import 用模块级 get_config）
+    return db, cache_dir, ui
+
+
+def _make_img(path, color, size=96):
+    Image.new("RGB", (size, size), color).save(path)
+
+
+def test_concurrent_same_image_yields_single_row(env):
+    db, cache_dir, ui = env
+    same = cache_dir / "_con_same.png"
+    _make_img(str(same), (200, 30, 40))
+    copies = [cache_dir / f"same{i}.png" for i in range(2)]
+    for c in copies:
+        shutil.copy2(str(same), c)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        list(ex.map(lambda c: ui._do_import([str(c)], ["same"]), copies))
+
+    assert len(db.get_all()) == 1
+
+
+def test_concurrent_different_images_both_imported(env):
+    db, cache_dir, ui = env
+    a = cache_dir / "a.png"
+    b = cache_dir / "b.png"
+    _make_img(str(a), (10, 200, 30))
+    _make_img(str(b), (30, 40, 200))
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        list(ex.map(lambda p: ui._do_import([str(p)], [p.stem]), (a, b)))
+
+    assert len(db.get_all()) == 2
+
+
+def test_ensure_collection_same_name_reused(env):
+    """同名分组复用：两次 ensure 返回同一 cid，且不产生重复空分组"""
+    db, cache_dir, ui = env
+    # 造 2 条 meme 记录拿 id
+    ids = []
+    for i in range(2):
+        mid = db.add_meme(
+            filename=f"g{i}.png",
+            file_hash=f"h{i}",
+            width=8,
+            height=8,
+            file_size=100,
+            mime_type="image/png",
+            original_name=f"g{i}",
+        )
+        ids.append(mid)
+    c1 = ui.ensure_import_collection(ids, "Telegram")
+    # 不同时间再次导入新图并 ensure 同名 → cid 一致
+    ids2 = [
+        db.add_meme(
+            filename="g2.png",
+            file_hash="h9",
+            width=8,
+            height=8,
+            file_size=100,
+            mime_type="image/png",
+            original_name="g2",
+        )
+    ]
+    c2 = ui.ensure_import_collection(ids2, "Telegram")
+    assert c1 == c2 and c1 > 0
+    # collections 无重复空分组
+    conn = db._get_conn()
+    cnt = conn.execute(
+        "SELECT COUNT(*) FROM collections WHERE name='Telegram'"
+    ).fetchone()[0]
+    assert cnt == 1  # 不是 2！
+
+
+def test_ensure_collection_empty_args(env):
+    """空 ids / 空 group_name 返回 -1，不建任何分组"""
+    db, cache_dir, ui = env
+    assert ui.ensure_import_collection([], "Telegram") == -1
+    assert ui.ensure_import_collection([1], "") == -1
+    assert ui.ensure_import_collection([], "") == -1

--- a/tests/test_phash.py
+++ b/tests/test_phash.py
@@ -1,0 +1,77 @@
+"""感知哈希算法单元测试：同内容不同编码应判相似，不同内容应判相异"""
+
+import random
+
+from PIL import Image
+
+from src.webui import (
+    _PHASH_SIMILAR_DIST,
+    _perceptual_hash,
+    _phash_hamming,
+)
+
+
+def _textured(seed=0, size=96):
+    """带随机纹理的照片样式图（每像素低频偏置+高频细节），模拟真实表情包"""
+    rng = random.Random(seed)
+    img = Image.new("RGB", (size, size))
+    px = img.load()
+    # 低频底色渐变
+    for y in range(size):
+        for x in range(size):
+            base_r = (x * 200) // size
+            base_g = (y * 200) // size
+            base_b = ((x + y) * 100) // size
+            px[x, y] = (
+                min(255, max(0, base_r + rng.randint(-25, 25))),
+                min(255, max(0, base_g + rng.randint(-25, 25))),
+                min(255, max(0, base_b + rng.randint(-25, 25))),
+            )
+    return img
+
+
+class TestPerceptualHash:
+    def test_self_distance_zero(self):
+        img = _textured()
+        assert _phash_hamming(_perceptual_hash(img), _perceptual_hash(img)) == 0
+
+    def test_same_content_resample_similar(self):
+        # 同一内容轻微重采样后应判相似（用户原始场景）
+        img = _textured()
+        rep = img.resize((48, 48), Image.LANCZOS).resize((96, 96), Image.LANCZOS)
+        d = _phash_hamming(_perceptual_hash(img), _perceptual_hash(rep))
+        assert d <= _PHASH_SIMILAR_DIST
+
+    def test_same_content_brightness_shift_similar(self):
+        # 整体亮度偏移仍应相似
+        img = _textured()
+        br = Image.eval(img, lambda v: min(255, int(v * 1.3) + 10))
+        d = _phash_hamming(_perceptual_hash(img), _perceptual_hash(br))
+        assert d <= _PHASH_SIMILAR_DIST
+
+    def test_same_content_convert_format_similar(self):
+        # 同内容转码（压缩损失）应相似
+        import io
+
+        img = _textured()
+        buf = io.BytesIO()
+        img.save(buf, "JPEG", quality=70)
+        buf.seek(0)
+        rejoined = Image.open(buf).convert("RGB")
+        d = _phash_hamming(_perceptual_hash(img), _perceptual_hash(rejoined))
+        assert d <= _PHASH_SIMILAR_DIST
+
+    def test_different_images_not_similar(self):
+        # 完全不同内容应相异
+        d = _phash_hamming(
+            _perceptual_hash(_textured(1)), _perceptual_hash(_textured(999))
+        )
+        assert d > _PHASH_SIMILAR_DIST
+
+    def test_light_backgrounds_still_distinct(self):
+        # 浅色大底但内容不同的图（此前的误判样本类型，非纯色）应能区分
+        a = _textured(11)
+        # 把 a 抹成偏浅色，但保留纹理差异；再做一张纹理不同的浅色图
+        b = _textured(22)
+        da = _phash_hamming(_perceptual_hash(a), _perceptual_hash(b))
+        assert da > _PHASH_SIMILAR_DIST

--- a/tests/test_phash.py
+++ b/tests/test_phash.py
@@ -70,8 +70,8 @@ class TestPerceptualHash:
 
     def test_light_backgrounds_still_distinct(self):
         # 浅色大底但内容不同的图（此前的误判样本类型，非纯色）应能区分
-        a = _textured(11)
-        # 把 a 抹成偏浅色，但保留纹理差异；再做一张纹理不同的浅色图
-        b = _textured(22)
+        # 把 a 调亮成偏浅色背景（保留纹理），与另一张纹理不同的浅色图对比
+        a = Image.eval(_textured(11), lambda v: min(255, int(v * 1.6) + 60))
+        b = Image.eval(_textured(22), lambda v: min(255, int(v * 1.6) + 60))
         da = _phash_hamming(_perceptual_hash(a), _perceptual_hash(b))
         assert da > _PHASH_SIMILAR_DIST


### PR DESCRIPTION
## 背景

本轮系统改进导入链路与相似图去重，覆盖用户实测反馈的多处体验问题：
- Windows 快速拖动窗口滞后/抖动
- 文件夹/多文件导入无进行中进度
- "内容一致但字节不同"的相似图无感知检测、且并发导入会产生重复记录
- 各渠道导入未自动分组、重复导入同文件夹会残留重复空分组

## 变更内容

### 1. 窗口拖动（Windows/macOS 增量回退路径）
`src/vue-src/App.vue`、`src/webui/index.js`、`src/webui/settings.js`、`src/webui.py`
- 拖动改为**相对起点的总偏移 + rAF 合并**发送，后端 8ms 节流 + 绝对目标定位，彻底修复高回报率鼠标下的滞后/抖动（screenX/screenY，未改 clientX/clientY）。

### 2. 存储位置迁移进度
`src/webui.py`、`src/webui/settings.html`、`src/webui/settings.js`
- 迁移改为**后台线程 + 进度状态**，设置页覆盖层展示进度/计数、支持取消与后台运行；失败/取消自动回滚已移动文件。

### 3. 感知哈希相似图去重
`src/webui.py`、`src/database.py`、`src/vue-src/components/SimilarImportDialog.vue`、`src/vue-src/App.vue`
- `memes.perceptual_hash` 列（**TEXT 存 hex**，旧库 ALTER 安全迁移）持久化每张图 64 位 pHash（8x8 可分离 DCT，比均值哈希对浅色/低信息图判别力更强）。
- 导入哈希未命中时 `_find_similar_candidates` **只算新图 phash + 从 DB 读存量比对**（整数 XOR，微秒级）；旧库 phash 为空行惰性回填（后台线程，`_PHASH_BACKFILLING` 防重入）。
- 命中近似（汉明距离 ≤12）时弹 `SimilarImportDialog`：保留新图 / 保留旧图 / 跳过 / 都保留，经 `resolve_similar_import` 处理。
- **URL 拖放与 File(`/api/upload/`) 单张统一走相似决策**；哈希精确命中提示「已存在」。

### 4. 并发导入防重复
`src/webui.py`
- `_do_import` 去重关键区（`get_by_hash`→copy2→`add_meme`→回查）加 `_IMPORT_LOCK` 串行化，并发导入相同字节图不再产生重复记录（实测 4 线程同图仅 1 条）。

### 5. 交互式导入后台化 + 进度
`src/webui.py`、`src/vue-src/components/ImportProgressOverlay.vue`、`src/vue-src/components/ImportMenu.vue`、`src/vue-src/App.vue`
- `_do_import` 加可选 `progress_cb`（逐文件回调，返回 False 中断取消）。
- 文件夹/文件对话框导入改**后台线程 + `_IMPORT_JOB_STATE`**，前端 `ImportProgressOverlay` 300ms 轮询进度条 + 取消 + 后台运行；剪贴板保持同步（单张瞬时）。

### 6. 渠道自动分组 + 同名复用修复
`src/webui.py`、`src/database.py`、`src/tg_stickers.py`、`src/douyin.py`、`src/wechat_probe.py`
- TG/抖音/微信 导入后 `ensure_import_collection` 自动归入固定名分组（Telegram/抖音/微信），同一渠道不同时间导入复用同名分组。QQ/QQNT 不入库故不建组。
- `create_collection` 改为**先按 name+parent_id 查已存在→返回既有 id，否则 INSERT**，不再产生重复空分组。

### 7. 测试
- 新增 `tests/test_phash.py`（感知哈希 6 用例：自距/重采样/亮度/JPEG转码/异图/浅色图）
- 新增 `tests/test_import_concurrency.py`（`_do_import` 并发去重 + 同名分组复用 + 空参）
- 全量 **218 passed**，`ruff check src/` 与 `black --check src/` 通过

## 影响 / 注意
- `memes` 表新增 `perceptual_hash` 列（TEXT），旧库启动时自动 `ALTER TABLE` 迁移，数据无损；phash 为空的行首次相似导入时后台补算。
- 打包需重新构建（新增 2 个 Vue 组件，`webui/dist/ohmymeme.js` 已重编）。

## 验证
- om venv（Pillow/pytest/pywebview）实测：5 图导入进度 0→100 done、30 图取消→cancelled 只导入 1、同名分组唯一成员合并、pHash 误判图区分 + 真相似保留、旧库迁移不崩。
- 窗口拖动态基准、turkey 迁移进度等均经端到端验证。

## Sourcery 摘要

通过响应式进度反馈、可靠的并发处理和自动整理，增强导入和相似度去重功能。

新功能：
- 添加基于感知哈希的相似度检测，并支持用户控制近似重复单图导入的处理方式。
- 提供支持进度显示、取消和回滚的后台导入及存储迁移任务。
- 自动整理 Telegram、Douyin 和 WeChat 导入内容，并复用现有分组。

错误修复：
- 防止相同图片并发导入时产生重复记录。
- 消除备用桌面拖动路径中的窗口拖动延迟和抖动。
- 防止复用相同集合名称时创建重复的空集合。

增强功能：
- 通过安全的数据库迁移持久化感知哈希，并对现有表情包进行延迟回填。
- 统一 URL 拖放和单文件上传中的重复及相似度判定逻辑。
- 通过进度覆盖层和后台执行，改进导入及迁移过程的反馈。

构建：
- 更新打包后的前端构建产物，以包含新的导入进度和相似度对话框。

文档：
- 记录感知哈希去重、后台导入、自动频道分组和并发安全机制。

测试：
- 添加感知哈希行为测试，以及并发导入和分组复用覆盖测试；完整测试套件和代码质量检查均已通过。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过响应式后台工作流、感知相似度检测和并发安全的去重机制，提升导入的可靠性与组织性。

新功能：
- 添加感知哈希相似度检测，并允许用户控制近重复单图导入的处理方式。
- 提供支持进度报告、取消和回滚的后台导入及存储迁移工作流。
- 自动将 Telegram、Douyin 和 WeChat 导入的内容整理到可复用的频道集合中。

错误修复：
- 防止相同图像并发导入时产生重复记录。
- 修复备用窗口拖动路径中的延迟和抖动问题。
- 防止重复使用相同集合名称时创建重复的空集合。

增强：
- 持久化感知哈希，并为现有记录提供安全迁移和延迟回填。
- 统一处理 URL 拖放和单文件上传中的精确重复与相似图像判定。

构建：
- 更新内置前端构建，加入新的导入进度和相似度对话框。

文档：
- 更新有关感知去重、后台导入、自动频道集合和并发导入安全性的项目指南。

测试：
- 添加感知哈希行为测试，以及并发导入和集合复用覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过感知相似度去重、响应式后台工作流和并发安全的集合处理，提升导入的可靠性与组织能力。

新功能：
- 添加感知哈希相似度检测，并允许用户控制对近似重复的单图导入的处理方式。
- 提供支持进度报告、取消和回滚的后台导入与存储迁移工作流。
- 自动将 Telegram、抖音和微信导入内容整理到可复用的频道集合中。

错误修复：
- 防止相同图片并发导入时产生重复记录。
- 修复备用窗口拖动路径中的延迟和抖动问题。
- 防止重复使用同一集合名称时产生重复的空集合。

增强：
- 通过安全的数据库迁移持久化感知哈希，并为现有表情包延迟补全哈希。
- 统一 URL 拖放和单文件上传中的完全重复与相似度判断逻辑。

构建：
- 使用新的导入进度和相似度对话框更新打包后的前端资源。

文档：
- 更新有关感知去重、后台导入、自动频道集合和并发导入安全性的项目指南。

测试：
- 添加感知哈希行为测试，以及并发导入和集合复用覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过感知相似度去重、响应式后台工作流以及更安全的并发处理，提升导入的可靠性和组织性。

新功能：
- 添加感知哈希相似度检测，支持用户控制近似重复单图导入的处理方式。
- 提供后台导入和存储迁移工作流，支持进度报告、取消、后台执行和回滚。
- 自动将 Telegram、Douyin 和 WeChat 导入的内容整理到可复用的频道集合中。

错误修复：
- 防止相同图片并发导入时产生重复记录。
- 消除备用窗口拖动路径中的卡顿和抖动。
- 防止重复使用同一集合名称时创建重复的空集合。

改进：
- 通过安全的数据库迁移和对现有记录的延迟回填，持久化保存感知哈希。
- 统一处理 URL 拖放和单文件上传中的完全重复与相似度判断。
- 通过进度覆盖层和支持逐文件取消的功能，改进导入反馈。

构建：
- 更新内置前端资源，加入导入进度和相似导入界面。

文档：
- 添加感知哈希去重、后台导入、自动频道集合以及并发导入安全性的相关文档。

测试：
- 添加感知哈希行为测试，以及并发导入和集合复用的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过感知相似度去重、响应式后台工作流和更安全的并发组织方式，改进导入功能。

新功能：
- 添加感知哈希相似度检测，并允许用户控制对近似重复单图导入的处理方式。
- 提供后台导入和存储迁移工作流，支持进度报告、取消和回滚。
- 自动将 Telegram、Douyin 和 WeChat 导入的内容整理到可复用的命名集合中。

Bug 修复：
- 防止在并发导入相同图片时创建重复记录。
- 修复备用窗口拖动路径中的延迟和抖动问题。
- 防止在复用同一集合名称时创建重复的空集合。

增强：
- 通过安全的数据库迁移持久化感知哈希，并为现有 memes 延迟补全哈希。
- 统一 URL 拖放和单文件上传中的精确重复与相似度判断逻辑。

构建：
- 更新打包后的前端资源，加入导入进度和相似导入界面。

文档：
- 编写感知哈希去重、后台导入、自动频道集合和并发导入安全性的相关文档。

测试：
- 添加感知哈希行为测试，以及并发导入和集合复用覆盖测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve importing with perceptual similarity deduplication, responsive background workflows, and safer concurrent organization.

New Features:
- Add perceptual-hash similarity detection with user-controlled handling for near-duplicate single-image imports.
- Provide background import and storage migration workflows with progress reporting, cancellation, and rollback.
- Automatically organize Telegram, Douyin, and WeChat imports into reusable named collections.

Bug Fixes:
- Prevent duplicate records when identical images are imported concurrently.
- Fix lag and jitter in fallback window dragging paths.
- Prevent duplicate empty collections when reusing the same collection name.

Enhancements:
- Persist perceptual hashes with safe database migration and lazy backfilling for existing memes.
- Unify exact-duplicate and similarity decisions across URL drops and single-file uploads.

Build:
- Update the packaged frontend assets with the import progress and similar-import interfaces.

Documentation:
- Document perceptual-hash deduplication, background imports, automatic channel collections, and concurrent import safety.

Tests:
- Add perceptual-hash behavior tests and concurrent import and collection-reuse coverage.

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 导入图片时支持识别重复或相似内容，并提供保留、替换、跳过等处理选项。
  - 文件及文件夹导入支持后台执行、进度显示、取消和后台运行。
  - 存储目录迁移新增进度展示、取消及后台运行功能。
  - 抖音、Telegram 和微信导入内容会自动归入对应分组。

- **改进**
  - 优化并发导入去重、窗口拖动及错误处理，提升稳定性。
  - 文件夹导入与分组处理提示更加简洁。
  - 导入完成后显示跳过的重复项目数量。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->