### PR TITLE
fix(ui): 设置窗口打开后数秒无法交互（多线程服务器 + contributors 缓存）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ tests/
 ### 本地 HTTP 安全加固
 - Bottle 只绑 `127.0.0.1` 随机端口；`before_request` 校验 `Host` 必须为本机回环（`_host_allowed`），POST 额外校验 `Origin` 同源且 `Sec-Fetch-Site` 非 `cross-site`，拒绝则 403（阻断 DNS rebinding / 跨站注入）
 - **多线程服务器**：`bottle.run` 通过 `server_class=_ThreadedWSGIServer`（`ThreadingMixIn + WSGIServer`，`daemon_threads=True`）启用多线程——Bottle 默认 wsgiref 单线程串行处理，慢请求（`/api/contributors` 外网抓取、`/api/thumb` 现场生成缩略图）会阻塞其他路由投递，导致设置页 `settings.js`/`settings.css` 排队、JS 监听未注册期间窗口可见但拖动/点击全部无效
-- `/api/contributors` 结果带 1h TTL 缓存（模块级 `_CONTRIBUTORS_CACHE`，过期抓取失败回退旧缓存），设置页该图片加 `loading="lazy"`（位于默认隐藏的「关于」section，仅切换到该分组时才发起请求）；缩略图生成写盘为先写临时文件再 `os.replace` 原子替换（多线程下并发请求同一未缓存缩略图不再交错写产生永久损坏的缓存文件）
+- `/api/contributors` 结果带 1h TTL 缓存（模块级 `_CONTRIBUTORS_CACHE`，刷新在 `_CONTRIBUTORS_LOCK` 内单飞，防并发重复抓取；刷新失败回退旧缓存并退避 60s 重试，不再每个请求都反复触发 10s 慢抓取），设置页该图片加 `loading="lazy"`（位于默认隐藏的「关于」section，仅切换到该分组时才发起请求）；缩略图生成写盘为先写临时文件再 `os.replace` 原子替换（多线程下并发请求同一未缓存缩略图不再交错写产生永久损坏的缓存文件）
 - `after_request` 统一加 `X-Content-Type-Options: nosniff` / `Referrer-Policy: no-referrer` / `X-Frame-Options: DENY`，`/api/` 路由 `Cache-Control: no-store`
 - 文件名安全：`_safe_serve_filename`（webui）与 `_safe_remote_fname`（sync）拒绝含 `/` `\`、以 `.` `/` `\` `~` `..` 开头的名字；`_find_meme_file` 入口校验，远端 manifest 文件名在 `_fetch_remote_memes` 过滤 + `_pull_worker` 写盘前再防御
 - 前端 XSS：`utils/api.ts` 的 `esc()`/`renderMarkdown()` 转义所有拼入 innerHTML 的外部/动态数据（远端分组名、GitHub 版本号、QQ 昵称、输出目录、弹窗标题/正文等）；设置窗口 `settings.js` 同理

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ tests/
 ### 本地 HTTP 安全加固
 - Bottle 只绑 `127.0.0.1` 随机端口；`before_request` 校验 `Host` 必须为本机回环（`_host_allowed`），POST 额外校验 `Origin` 同源且 `Sec-Fetch-Site` 非 `cross-site`，拒绝则 403（阻断 DNS rebinding / 跨站注入）
 - **多线程服务器**：`bottle.run` 通过 `server_class=_ThreadedWSGIServer`（`ThreadingMixIn + WSGIServer`，`daemon_threads=True`）启用多线程——Bottle 默认 wsgiref 单线程串行处理，慢请求（`/api/contributors` 外网抓取、`/api/thumb` 现场生成缩略图）会阻塞其他路由投递，导致设置页 `settings.js`/`settings.css` 排队、JS 监听未注册期间窗口可见但拖动/点击全部无效
-- `/api/contributors` 结果带 1h TTL 缓存（模块级 `_CONTRIBUTORS_CACHE`，刷新在 `_CONTRIBUTORS_LOCK` 内单飞，防并发重复抓取；刷新失败回退旧缓存并退避 60s 重试，不再每个请求都反复触发 10s 慢抓取），设置页该图片加 `loading="lazy"`（位于默认隐藏的「关于」section，仅切换到该分组时才发起请求）；缩略图生成写盘为先写临时文件再 `os.replace` 原子替换（多线程下并发请求同一未缓存缩略图不再交错写产生永久损坏的缓存文件）
+- `/api/contributors` 结果带 1h TTL 缓存（模块级 `_CONTRIBUTORS_CACHE`，刷新在 `_CONTRIBUTORS_LOCK` 内单飞：**取锁后刷新时间并重查退避期**，等待中的并发请求不再重复抓取；刷新失败一律退避 60s 重试——有旧缓存回退旧缓存，无缓存冷启动失败返回 502，不再每个请求都反复触发 10s 慢抓取），设置页该图片加 `loading="lazy"`（位于默认隐藏的「关于」section，仅切换到该分组时才发起请求）；缩略图生成写盘为先写临时文件再 `os.replace` 原子替换（多线程下并发请求同一未缓存缩略图不再交错写产生永久损坏的缓存文件）
 - `after_request` 统一加 `X-Content-Type-Options: nosniff` / `Referrer-Policy: no-referrer` / `X-Frame-Options: DENY`，`/api/` 路由 `Cache-Control: no-store`
 - 文件名安全：`_safe_serve_filename`（webui）与 `_safe_remote_fname`（sync）拒绝含 `/` `\`、以 `.` `/` `\` `~` `..` 开头的名字；`_find_meme_file` 入口校验，远端 manifest 文件名在 `_fetch_remote_memes` 过滤 + `_pull_worker` 写盘前再防御
 - 前端 XSS：`utils/api.ts` 的 `esc()`/`renderMarkdown()` 转义所有拼入 innerHTML 的外部/动态数据（远端分组名、GitHub 版本号、QQ 昵称、输出目录、弹窗标题/正文等）；设置窗口 `settings.js` 同理

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,8 @@ tests/
 
 ### 本地 HTTP 安全加固
 - Bottle 只绑 `127.0.0.1` 随机端口；`before_request` 校验 `Host` 必须为本机回环（`_host_allowed`），POST 额外校验 `Origin` 同源且 `Sec-Fetch-Site` 非 `cross-site`，拒绝则 403（阻断 DNS rebinding / 跨站注入）
+- **多线程服务器**：`bottle.run` 通过 `server_class=_ThreadedWSGIServer`（`ThreadingMixIn + WSGIServer`，`daemon_threads=True`）启用多线程——Bottle 默认 wsgiref 单线程串行处理，慢请求（`/api/contributors` 外网抓取、`/api/thumb` 现场生成缩略图）会阻塞其他路由投递，导致设置页 `settings.js`/`settings.css` 排队、JS 监听未注册期间窗口可见但拖动/点击全部无效
+- `/api/contributors` 结果带 1h TTL 缓存（模块级 `_CONTRIBUTORS_CACHE`，过期抓取失败回退旧缓存），设置页该图片加 `loading="lazy"`（位于默认隐藏的「关于」section，仅切换到该分组时才发起请求）；缩略图生成写盘为先写临时文件再 `os.replace` 原子替换（多线程下并发请求同一未缓存缩略图不再交错写产生永久损坏的缓存文件）
 - `after_request` 统一加 `X-Content-Type-Options: nosniff` / `Referrer-Policy: no-referrer` / `X-Frame-Options: DENY`，`/api/` 路由 `Cache-Control: no-store`
 - 文件名安全：`_safe_serve_filename`（webui）与 `_safe_remote_fname`（sync）拒绝含 `/` `\`、以 `.` `/` `\` `~` `..` 开头的名字；`_find_meme_file` 入口校验，远端 manifest 文件名在 `_fetch_remote_memes` 过滤 + `_pull_worker` 写盘前再防御
 - 前端 XSS：`utils/api.ts` 的 `esc()`/`renderMarkdown()` 转义所有拼入 innerHTML 的外部/动态数据（远端分组名、GitHub 版本号、QQ 昵称、输出目录、弹窗标题/正文等）；设置窗口 `settings.js` 同理

--- a/src/webui.py
+++ b/src/webui.py
@@ -80,9 +80,12 @@ _LOG_MAX = 5000
 # 分页：主窗口单页展示的表情包数量（与前端 index.js MEME_PAGE 保持一致）
 MEME_PAGE = 200
 
-# 贡献者 SVG 缓存：TTL 1 小时，避免每次打开设置页都请求外网
+# 贡献者 SVG 缓存：TTL 1 小时，避免每次打开设置页都请求外网；刷新失败退避
+# 重试，避免上游不可用时每个请求都反复触发 10s 慢抓取
 _CONTRIBUTORS_TTL = 3600
-_CONTRIBUTORS_CACHE = {"svg": None, "at": 0.0}
+_CONTRIBUTORS_RETRY_INTERVAL = 60
+_CONTRIBUTORS_LOCK = threading.Lock()
+_CONTRIBUTORS_CACHE = {"svg": None, "at": 0.0, "next_retry": 0.0}
 
 
 class _LogBufferHandler(logging.Handler):
@@ -114,6 +117,15 @@ install_log_buffer()
 
 HTML_DIR = Path(__file__).resolve().parent / "webui"
 RESOURCES_DIR = Path(__file__).resolve().parent / "resources"
+
+
+def _contributors_svg():
+    """剥离缓存 SVG 的白色背景矩形，适配深色主题后返回"""
+    white_rect = '<rect width="100%" height="100%" fill="#ffffff"/>'
+    svg = _CONTRIBUTORS_CACHE["svg"].replace(white_rect, "")
+    bottle.response.content_type = "image/svg+xml; charset=utf-8"
+    return svg
+
 
 # 启动动画视频边缘主色（OhMyMeme.mp4 边框纯黑，写死避免运行时 ffmpeg 抽帧采样）
 _STARTUP_BG_COLOR = "#000000"
@@ -3353,28 +3365,39 @@ class WebUI:
 
         @app.route("/api/contributors")
         def serve_contributors():
-            # 代理贡献者 SVG：剥离白色背景矩形，适配深色主题；TTL 缓存，失败回退旧缓存
+            # 代理贡献者 SVG：剥离白色背景矩形，适配深色主题；TTL 缓存 + 单飞
+            # 刷新（锁内抓取），失败退避 60s 并回退旧缓存
             now = time.time()
             if _CONTRIBUTORS_CACHE["svg"] is None or now >= (
                 _CONTRIBUTORS_CACHE["at"] + _CONTRIBUTORS_TTL
             ):
-                try:
-                    from urllib.request import Request, urlopen
+                # 是否已过退避期（缓存不存在时永远尝试）
+                if _CONTRIBUTORS_CACHE["svg"] is not None and now < (
+                    _CONTRIBUTORS_CACHE["next_retry"]
+                ):
+                    return _contributors_svg()
+                with _CONTRIBUTORS_LOCK:
+                    if _CONTRIBUTORS_CACHE["svg"] is None or now >= (
+                        _CONTRIBUTORS_CACHE["at"] + _CONTRIBUTORS_TTL
+                    ):
+                        try:
+                            from urllib.request import Request, urlopen
 
-                    url = "https://contributor.starsfire.top/TNTXZ/OhMyMeme"
-                    req = Request(url, headers={"User-Agent": "OhMyMeme"})
-                    with urlopen(req, timeout=10) as resp:
-                        svg = resp.read().decode("utf-8", "replace")
-                    _CONTRIBUTORS_CACHE["svg"] = svg
-                    _CONTRIBUTORS_CACHE["at"] = now
-                except Exception:
-                    if _CONTRIBUTORS_CACHE["svg"] is None:
-                        bottle.response.status = 502
-                        return ""
-            white_rect = '<rect width="100%" height="100%" fill="#ffffff"/>'
-            svg = _CONTRIBUTORS_CACHE["svg"].replace(white_rect, "")
-            bottle.response.content_type = "image/svg+xml; charset=utf-8"
-            return svg
+                            url = "https://contributor.starsfire.top/TNTXZ/OhMyMeme"
+                            req = Request(url, headers={"User-Agent": "OhMyMeme"})
+                            with urlopen(req, timeout=10) as resp:
+                                svg = resp.read().decode("utf-8", "replace")
+                            _CONTRIBUTORS_CACHE["svg"] = svg
+                            _CONTRIBUTORS_CACHE["at"] = now
+                        except Exception:
+                            if _CONTRIBUTORS_CACHE["svg"] is None:
+                                bottle.response.status = 502
+                                return ""
+                            # 保留旧缓存，退避后再尝试
+                            _CONTRIBUTORS_CACHE["next_retry"] = (
+                                now + _CONTRIBUTORS_RETRY_INTERVAL
+                            )
+            return _contributors_svg()
 
         @app.route("/api/thumb/<meme_id>/<filename>")
         def serve_thumb(meme_id, filename):

--- a/src/webui.py
+++ b/src/webui.py
@@ -6,6 +6,7 @@ import math
 import os
 import platform
 import socket
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -78,6 +79,10 @@ _LOG_MAX = 5000
 
 # 分页：主窗口单页展示的表情包数量（与前端 index.js MEME_PAGE 保持一致）
 MEME_PAGE = 200
+
+# 贡献者 SVG 缓存：TTL 1 小时，避免每次打开设置页都请求外网
+_CONTRIBUTORS_TTL = 3600
+_CONTRIBUTORS_CACHE = {"svg": None, "at": 0.0}
 
 
 class _LogBufferHandler(logging.Handler):
@@ -3082,7 +3087,18 @@ class WebUI:
             buf = io.BytesIO()
             img.save(buf, "PNG")
             cache_dir.mkdir(parents=True, exist_ok=True)
-            thumb_path.write_bytes(buf.getvalue())
+            # 并发请求同一缩略图时避免交错写同一文件：先写临时文件再原子替换
+            fd, tmp_path = tempfile.mkstemp(dir=str(cache_dir), suffix=".tmp")
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    f.write(buf.getvalue())
+                os.replace(tmp_path, thumb_path)
+            except Exception:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+                raise
             return str(thumb_path)
         except Exception as e:
             logger.warning(f"thumb error {filename}: {e}")
@@ -3337,21 +3353,28 @@ class WebUI:
 
         @app.route("/api/contributors")
         def serve_contributors():
-            # 代理贡献者 SVG：剥离白色背景矩形，适配深色主题
-            try:
-                from urllib.request import Request, urlopen
+            # 代理贡献者 SVG：剥离白色背景矩形，适配深色主题；TTL 缓存，失败回退旧缓存
+            now = time.time()
+            if _CONTRIBUTORS_CACHE["svg"] is None or now >= (
+                _CONTRIBUTORS_CACHE["at"] + _CONTRIBUTORS_TTL
+            ):
+                try:
+                    from urllib.request import Request, urlopen
 
-                url = "https://contributor.starsfire.top/TNTXZ/OhMyMeme"
-                req = Request(url, headers={"User-Agent": "OhMyMeme"})
-                with urlopen(req, timeout=10) as resp:
-                    svg = resp.read().decode("utf-8", "replace")
-                white_rect = '<rect width="100%" height="100%" fill="#ffffff"/>'
-                svg = svg.replace(white_rect, "")
-                bottle.response.content_type = "image/svg+xml; charset=utf-8"
-                return svg
-            except Exception:
-                bottle.response.status = 502
-                return ""
+                    url = "https://contributor.starsfire.top/TNTXZ/OhMyMeme"
+                    req = Request(url, headers={"User-Agent": "OhMyMeme"})
+                    with urlopen(req, timeout=10) as resp:
+                        svg = resp.read().decode("utf-8", "replace")
+                    _CONTRIBUTORS_CACHE["svg"] = svg
+                    _CONTRIBUTORS_CACHE["at"] = now
+                except Exception:
+                    if _CONTRIBUTORS_CACHE["svg"] is None:
+                        bottle.response.status = 502
+                        return ""
+            white_rect = '<rect width="100%" height="100%" fill="#ffffff"/>'
+            svg = _CONTRIBUTORS_CACHE["svg"].replace(white_rect, "")
+            bottle.response.content_type = "image/svg+xml; charset=utf-8"
+            return svg
 
         @app.route("/api/thumb/<meme_id>/<filename>")
         def serve_thumb(meme_id, filename):
@@ -3449,7 +3472,21 @@ class WebUI:
                 return bottle.static_file(filepath, root=str(HTML_DIR), mimetype=ctype)
             return bottle.static_file(filepath, root=str(HTML_DIR))
 
-        bottle.run(app, host="127.0.0.1", port=self._port, quiet=True)
+        # 多线程 wsgiref：默认单线程下慢请求（外网抓取/缩略图生成）会阻塞
+        # 其他路由，导致设置页资源排队、JS 监听未注册期间窗口无法交互
+        from socketserver import ThreadingMixIn
+        from wsgiref.simple_server import WSGIServer
+
+        class _ThreadedWSGIServer(ThreadingMixIn, WSGIServer):
+            daemon_threads = True
+
+        bottle.run(
+            app,
+            host="127.0.0.1",
+            port=self._port,
+            quiet=True,
+            server_class=_ThreadedWSGIServer,
+        )
 
     # --- 缓存扫描 ---
 

--- a/src/webui.py
+++ b/src/webui.py
@@ -3371,15 +3371,17 @@ class WebUI:
             if _CONTRIBUTORS_CACHE["svg"] is None or now >= (
                 _CONTRIBUTORS_CACHE["at"] + _CONTRIBUTORS_TTL
             ):
-                # 是否已过退避期（缓存不存在时永远尝试）
-                if _CONTRIBUTORS_CACHE["svg"] is not None and now < (
-                    _CONTRIBUTORS_CACHE["next_retry"]
-                ):
-                    return _contributors_svg()
                 with _CONTRIBUTORS_LOCK:
+                    # 取锁后刷新时间并重查退避期：等待中的并发请求不再重复抓取
+                    now = time.time()
                     if _CONTRIBUTORS_CACHE["svg"] is None or now >= (
                         _CONTRIBUTORS_CACHE["at"] + _CONTRIBUTORS_TTL
                     ):
+                        if now < _CONTRIBUTORS_CACHE["next_retry"]:
+                            if _CONTRIBUTORS_CACHE["svg"] is None:
+                                bottle.response.status = 502
+                                return ""
+                            return _contributors_svg()
                         try:
                             from urllib.request import Request, urlopen
 
@@ -3390,13 +3392,13 @@ class WebUI:
                             _CONTRIBUTORS_CACHE["svg"] = svg
                             _CONTRIBUTORS_CACHE["at"] = now
                         except Exception:
-                            if _CONTRIBUTORS_CACHE["svg"] is None:
-                                bottle.response.status = 502
-                                return ""
-                            # 保留旧缓存，退避后再尝试
+                            # 失败一律退避（含无缓存冷启动），防并发请求反复触发网络重试
                             _CONTRIBUTORS_CACHE["next_retry"] = (
                                 now + _CONTRIBUTORS_RETRY_INTERVAL
                             )
+                            if _CONTRIBUTORS_CACHE["svg"] is None:
+                                bottle.response.status = 502
+                                return ""
             return _contributors_svg()
 
         @app.route("/api/thumb/<meme_id>/<filename>")

--- a/src/webui/settings.html
+++ b/src/webui/settings.html
@@ -378,7 +378,7 @@
       <div id="s-update-status" class="about-update-status"></div>
       <div class="section-title">贡献者</div>
       <div class="about-contributors">
-        <img id="contributors-img" src="/api/contributors" alt="项目贡献者" onerror="document.getElementById('contributors-img').style.display='none';document.getElementById('contributors-fallback').style.display='block'">
+        <img id="contributors-img" src="/api/contributors" loading="lazy" alt="项目贡献者" onerror="document.getElementById('contributors-img').style.display='none';document.getElementById('contributors-fallback').style.display='block'">
       </div>
       <div id="contributors-fallback" style="display:none;font-size:11.5px;color:var(--muted)">贡献者名单加载失败</div>
     </div>


### PR DESCRIPTION
## 问题
 
Windows 实测：打开设置窗口后界面卡住数秒，表现为**拖动无效、点击无效**，一段时间后自行恢复。已排除更新检查阻塞（更新检查早已非阻塞化）。
 
## 根因
 
本地 Bottle 服务器一直是**单线程**：`bottle.run(...)` 未指定 server 参数，默认走 wsgiref 的 `WSGIServer`，串行处理请求（已核实 bottle 0.13 源码 `WSGIRefServer.run`）。
 
设置页 `settings.html` 写死 `<img src="/api/contributors">`，**页面一解析就发起**该请求；对应路由用 urllib 抓取外网 `contributor.starsfire.top`，`timeout=10` 且无任何缓存——网络慢或失败时这一个请求最长占住服务器线程 10 秒。期间 `/settings.js`、`/settings.css` 全部排队；设置窗口的全部拖动/点击监听都定义在 settings.js 里，脚本投递被堵期间窗口看得见但完全无法交互。
 
加重因素：打开设置瞬间主窗口常在通过同一服务器批量加载 `/api/thumb/*`（未命中缓存时现场用 PIL 生成，单张可达数百毫秒），进一步延迟 settings.js 的投递。
 
## 改动
 
| 文件 | 改动 |
|---|---|
| `src/webui.py` | `bottle.run` 经 `server_class=_ThreadedWSGIServer`（`ThreadingMixIn + WSGIServer`，`daemon_threads=True`）启用多线程，零新依赖 |
| `src/webui.py` | `/api/contributors` 加 1h TTL 缓存（模块级 `_CONTRIBUTORS_CACHE`），过期抓取失败回退旧缓存 |
| `src/webui/settings.html` | 贡献者图片加 `loading="lazy"`（位于默认隐藏的「关于」分组，仅切到该分组时才请求） |
| `src/webui.py` | 缩略图写盘改为临时文件 + `os.replace` 原子替换，杜绝并发交错写产生永久损坏的缩略图缓存 |
| `AGENTS.md` | 同步更新「本地 HTTP 安全加固」小节 |
 
## 线程安全影响评估
 
- Bottle 的 request/response 为 thread-local，路由并发安全；`before_request` 的 Host/Origin 校验与 `after_request` 安全头对每个并发请求照常生效
- 数据库本就支持并发（`threading.local()` 连接 + 写锁，同步模块线程池一直在多线程访问）；导入去重关键区已有 `_IMPORT_LOCK`，同步进度有 `_sync_lock`
- 线程数理论上无上限，但浏览器对同一 HTTP/1.1 主机最多约 6 个并发连接，实际并发线程天然有界；服务仍只绑 `127.0.0.1`
- 缩略图并发生成的写盘竞态已用原子替换消除（读者只会看到完整的旧文件或新文件）
 
## 验证
 
- `black --check src/`、`ruff check src/` 全部通过
- `pytest tests/`：225 passed, 1 skipped
- 冒烟测试：并发场景下 2s 慢请求不再阻塞其他请求（fast 0.00s 返回），确认 `server_class` 透传真实生效
- 待人工验证：运行应用打开设置窗口，确认拖动/点击即时响应
 
## 附注
 
已知次要因素（本次未处理）：`get_settings` 对已配置的同步密钥做 PBKDF2 解密（600k 迭代 × 每个密钥），配置过同步密码时表单填充会延迟 1-2s，仅影响表单填充速度，不冻结窗口。

## Sourcery 摘要

启用本地 Web 服务器的并发请求处理，并优化贡献者和缩略图资源加载，以确保设置窗口保持响应。

错误修复：
- 防止慢速本地服务器请求进行期间设置窗口暂时无响应。
- 避免并发生成过程中缩略图缓存文件永久损坏。
- 贡献者作品加载失败时，在缓存过期后允许回退到之前缓存的内容，而不是直接失败。

改进：
- 通过一小时缓存和延迟加载来改进贡献者作品的加载，直到用户查看相关设置部分时才加载。

文档：
- 记录线程化本地 HTTP 服务器、贡献者缓存与延迟加载，以及缩略图缓存的原子写入。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过启用并发本地 HTTP 请求，并增强贡献者和缩略图资源处理的健壮性，保持设置窗口的响应能力。

Bug 修复：
- 防止在处理缓慢的贡献者或缩略图请求时，设置窗口暂时无响应。
- 防止并发生成缩略图导致缓存文件损坏。
- 远程资源刷新失败时，保留之前缓存的贡献者 artwork。

改进：
- 通过一小时缓存、重试退避和延迟加载，改进贡献者 artwork 的加载。

文档：
- 记录线程化本地 HTTP 服务器、贡献者缓存与延迟加载，以及缩略图缓存的原子写入。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过允许本地请求并发处理，并增强贡献者和缩略图资源的处理能力，确保设置窗口保持响应。

错误修复：
- 通过启用本地 HTTP 请求的并发处理，避免缓慢的贡献者和缩略图请求导致设置窗口冻结。
- 防止并发生成缩略图时留下损坏的缓存文件。
- 刷新远程资源失败时，保留之前缓存的贡献者作品。

改进：
- 改进贡献者作品的加载：增加一小时缓存、重试退避机制，并延迟加载，直到用户查看相关设置部分。

文档：
- 记录线程化本地 HTTP 服务器、贡献者缓存与延迟加载，以及缩略图缓存的原子写入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep the settings window responsive by allowing concurrent local requests and making contributor and thumbnail resource handling more resilient.

Bug Fixes:
- Prevent slow contributor and thumbnail requests from freezing the settings window by enabling concurrent local HTTP request handling.
- Prevent concurrent thumbnail generation from leaving corrupted cache files.
- Preserve previously cached contributor artwork when refreshing the remote resource fails.

Enhancements:
- Improve contributor artwork loading with one-hour caching, retry backoff, and lazy loading until the relevant settings section is viewed.

Documentation:
- Document the threaded local HTTP server, contributor caching and lazy loading, and atomic thumbnail cache writes.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **性能与稳定性**
  - 优化本地服务并发处理，减少慢请求对其他页面和接口的影响。
  - 贡献者图片支持 1 小时缓存；获取失败时每 60 秒重试，并优先使用已有缓存。
  - 缩略图更新采用更安全的替换方式，降低文件损坏风险。
  - 设置页贡献者图片改为延迟加载，提升页面加载速度。

- **文档**
  - 补充本地 HTTP 安全与性能改进说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->