### PR TITLE
fix: 存储位置迁移三阶段幂等 + 启动自愈，修复跨盘迁移分裂状态

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ tests/
 - 密钥字段 (ftp_password, s3_secret_key 等) 用 Fernet 加密存储
 - 全局单例: `get_config()`, `get_db()`
 - `hotkey_show_at_mouse` 默认 `false`，控制 Windows 上全局热键显示隐藏主面板时是否按鼠标位置放置
-- `cache_dir`（表情包图片目录）可自定义：配置键 `cache_dir` 非空时 `Config.cache_dir` 返回该路径，否则默认 `data_dir/cache`；设置页「存储位置」通过 `SettingsApi.pick_storage_dir`/`apply_storage_dir` 切换，`apply_storage_dir` 可选把旧目录文件递归迁移（`os.walk`+`shutil.move`，两阶段：先预检目标同名冲突整体中止、移动中出错回滚，跳过 `thumbnails`）；**切换后旧文件不再可见**，故未迁移时必须确保文件已存在于新目录；`_storage_dir_validation` 拒绝相对/相同/上下级目录以及 `data_dir`/`thumbnail_dir` 及其上下级（受保护路径）；DB/缩略图/manifest 仍留在 `data_dir`，数据库只存文件名，文件在新目录时按 basename 自动解析；`reset_settings` 恢复默认时保留 `cache_dir`
+- `cache_dir`（表情包图片目录）可自定义：配置键 `cache_dir` 非空时 `Config.cache_dir` 返回该路径，否则默认 `data_dir/cache`；设置页「存储位置」通过 `SettingsApi.pick_storage_dir`/`apply_storage_dir` 切换，`apply_storage_dir` 可选把旧目录文件递归迁移（跳过 `thumbnails`）；**切换后旧文件不再可见**，故未迁移时必须确保文件已存在于新目录；`_storage_dir_validation` 拒绝相对/相同/上下级目录以及 `data_dir`/`thumbnail_dir` 及其上下级（受保护路径）；DB/缩略图/manifest 仍留在 `data_dir`，数据库只存文件名，文件在新目录时按 basename 自动解析；`reset_settings` 恢复默认时保留 `cache_dir`。迁移为**后台三阶段幂等**设计（避免跨盘长拷贝时进程被杀导致分裂状态）：①复制阶段源只读（`O_EXCL` 排他写入，dst 已存在且大小一致视为已复制跳过——幂等；失败/取消仅清理本次新副本，源完好无分裂，不回滚）；②写配置（唯一切换点，此后新目录已完整）；③删源（失败仅残留旧目录冗余，不阻断）。迁移开始写 `data_dir/storage_migration.json` 清单、完成后删除；`main.py` 启动时若检测到未完成清单则后台幂等续跑（强杀/断电后重启自愈）。取消由 move 回滚改为删新副本，消除回滚自身失败风险
 
 ### 同步
 - manifest 文件: `meme-index.json`

--- a/src/config.py
+++ b/src/config.py
@@ -222,11 +222,27 @@ class Config:
         self._dirty = True
 
     def save(self):
-        """持久化到磁盘（加锁，防止 pywebview 多线程并发写坏文件）"""
+        """持久化到磁盘（加锁 + 原子替换：先写临时文件再 os.replace，
+        避免写入中途失败/断电破坏原配置文件）"""
+        import tempfile
+
         with self._lock:
             self._path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._path, "w", encoding="utf-8") as f:
-                json.dump(self._data, f, ensure_ascii=False, indent=2)
+            fd, tmp = tempfile.mkstemp(
+                prefix=".config-",
+                suffix=".tmp",
+                dir=str(self._path.parent),
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(self._data, f, ensure_ascii=False, indent=2)
+                os.replace(tmp, self._path)
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
             self._dirty = False
 
     @property

--- a/src/main.py
+++ b/src/main.py
@@ -128,9 +128,17 @@ class OhMyMemeApp:
         except Exception as e:
             logger.debug("ADB init: %s", e)
 
+        # 6. 上次存储迁移未完成则后台幂等续迁（不阻塞启动）
+        try:
+            from .webui import resume_pending_storage_migration
+
+            resume_pending_storage_migration()
+        except Exception as e:
+            logger.debug("storage migration resume: %s", e)
+
         logger.info(f"{__app_name__} v{__version__} 已启动")
 
-        # 5. 启动 WebView GUI 循环（阻塞主线程）
+        # 7. 启动 WebView GUI 循环（阻塞主线程）
         try:
             self._webui.start()
         except Exception as e:

--- a/src/webui.py
+++ b/src/webui.py
@@ -1668,7 +1668,9 @@ def _storage_migrate_worker(old: Path, new: Path):
             except OSError:
                 continue
             if dst.exists():
-                if dst.stat().st_size == src_size:
+                if dst.stat().st_size == src_size and _file_sha256(src) == _file_sha256(
+                    str(dst)
+                ):
                     copied_pairs.append((src, dst))
                     moved = len(copied_pairs)
                     _set_storage_migrate(

--- a/src/webui.py
+++ b/src/webui.py
@@ -1637,14 +1637,19 @@ def _storage_migrate_worker(old: Path, new: Path):
     阶段1 只写新目录，崩溃/取消只需清理本次新副本（源完好无分裂）；
     阶段2 写配置是唯一切换点，此后新目录已完整；阶段3 删源失败仅残留
     旧目录冗余文件（rescan 只扫 cache_dir，无害）。
+
+    文件复制采用"迁移临时文件 + 原子提交"：先写入 dst 同目录的
+    .migrating 临时文件，完成后 os.replace 原子提交到 dst，避免写入中途
+    崩溃在最终路径留下半写文件（恢复时只需删除临时文件，不回滚已提交文件）。
     """
     import shutil
 
     copied_pairs = []
     created_dsts = []  # 本次运行实际新建的目标（取消/失败时清理，不动既有文件）
     config_switched = False  # 阶段2 配置已切换时禁止清理新目录文件
+    migrating_suffix = ".migrating"
     try:
-        # 阶段一：扫描 + 复制（幂等：dst 已存在且大小一致视为已复制）
+        # 阶段一：扫描 + 复制（幂等：dst 已存在且内容一致视为已复制）
         plan = []
         for root, dirs, files in os.walk(str(old)):
             rel = os.path.relpath(root, str(old))
@@ -1667,46 +1672,73 @@ def _storage_migrate_worker(old: Path, new: Path):
                 src_size = os.path.getsize(src)
             except OSError:
                 continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            tmp_dst = dst.parent / (dst.name + migrating_suffix)
+            # 清理上次中断留下的同路径临时文件（恢复入口）
+            if tmp_dst.exists():
+                tmp_dst.unlink()
             if dst.exists():
                 if dst.stat().st_size == src_size and _file_sha256(src) == _file_sha256(
                     str(dst)
                 ):
                     copied_pairs.append((src, dst))
-                    moved = len(copied_pairs)
                     _set_storage_migrate(
-                        progress=int(moved * 100 / total) if total else 100,
-                        moved=moved,
+                        progress=int(len(copied_pairs) * 100 / total) if total else 100,
+                        moved=len(copied_pairs),
                         current=os.path.basename(src),
                     )
                     continue
                 conflicts.append(dst)
                 continue
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            # 排他创建目标（O_EXCL：目标已存在则抛 FileExistsError，
-            # 防 precheck→write 期间并发覆盖既有文件）
             try:
-                fd = os.open(str(dst), os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o644)
-            except FileExistsError:
-                if dst.stat().st_size == src_size:
+                with open(src, "rb") as in_f, open(tmp_dst, "wb") as out_f:
+                    shutil.copyfileobj(in_f, out_f)
+            except Exception:
+                # 写入中途失败：仅删除本次临时文件，最终路径未触及
+                if tmp_dst.exists():
+                    tmp_dst.unlink()
+                raise
+            # 原子提交到最终路径（os.replace 同文件系统原子；不覆盖既有目标）
+            if dst.exists():
+                # 提交瞬间目标出现：校验内容，一致则视为已复制否则冲突
+                tmp_dst.unlink()
+                if dst.stat().st_size == src_size and _file_sha256(src) == _file_sha256(
+                    str(dst)
+                ):
                     copied_pairs.append((src, dst))
+                    _set_storage_migrate(
+                        progress=int(len(copied_pairs) * 100 / total) if total else 100,
+                        moved=len(copied_pairs),
+                        current=os.path.basename(src),
+                    )
                     continue
                 conflicts.append(dst)
                 continue
             try:
-                with os.fdopen(fd, "wb") as out_f, open(src, "rb") as in_f:
-                    shutil.copyfileobj(in_f, out_f)
-            except Exception:
-                try:
-                    os.unlink(str(dst))  # 清理复制中途失败留下的半写孤儿目标
-                except OSError:
-                    pass
-                raise
+                os.replace(str(tmp_dst), str(dst))
+            except OSError:
+                # 提交瞬间目标出现（极小窗口）：回退到内容校验
+                if (
+                    dst.exists()
+                    and dst.stat().st_size == src_size
+                    and _file_sha256(src) == _file_sha256(str(dst))
+                ):
+                    tmp_dst.unlink()
+                    copied_pairs.append((src, dst))
+                    _set_storage_migrate(
+                        progress=int(len(copied_pairs) * 100 / total) if total else 100,
+                        moved=len(copied_pairs),
+                        current=os.path.basename(src),
+                    )
+                    continue
+                tmp_dst.unlink()
+                conflicts.append(dst)
+                continue
             copied_pairs.append((src, dst))
             created_dsts.append(dst)
-            moved = len(copied_pairs)
             _set_storage_migrate(
-                progress=int(moved * 100 / total) if total else 100,
-                moved=moved,
+                progress=int(len(copied_pairs) * 100 / total) if total else 100,
+                moved=len(copied_pairs),
                 current=os.path.basename(src),
             )
         with _STORAGE_MIGRATE_LOCK:
@@ -1737,7 +1769,15 @@ def _storage_migrate_worker(old: Path, new: Path):
         # 阶段二：切换配置（唯一危险点，此后新目录已完整）
         get_config().set("cache_dir", str(new))
         get_config().save()
-        config_switched = True
+        # 依据磁盘上实际持久化的 cache_dir 判断是否已切换（原子保存保证一致，
+        # 但异常路径下以磁盘为准，避免误判为未切换而删除新目录）
+        try:
+            import json as _json
+
+            on_disk = _json.loads(get_config()._path.read_text(encoding="utf-8"))
+            config_switched = on_disk.get("cache_dir") == str(new)
+        except Exception:
+            config_switched = False
         # 阶段三：清理源文件（失败仅残留，不阻断不回滚）
         failed = []
         for src, _dst in copied_pairs:

--- a/src/webui.py
+++ b/src/webui.py
@@ -1550,10 +1550,63 @@ def cancel_storage_migration():
     return {"ok": True}
 
 
-def start_storage_migration_thread(new_dir: Path):
+def _storage_migrate_manifest_path() -> Path:
+    """迁移清单文件路径（崩溃后续跑依据）"""
+    return get_config().data_dir / "storage_migration.json"
+
+
+def _write_storage_migration_manifest(old: Path, new: Path):
+    import json
+
+    try:
+        with open(_storage_migrate_manifest_path(), "w", encoding="utf-8") as f:
+            json.dump({"old": str(old), "new": str(new)}, f)
+    except OSError:
+        pass
+
+
+def _clear_storage_migration_manifest():
+    try:
+        _storage_migrate_manifest_path().unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def resume_pending_storage_migration():
+    """启动自愈：存在未完成迁移清单则后台幂等续迁，成功前不阻塞启动"""
+    import json
+
+    manifest = _storage_migrate_manifest_path()
+    try:
+        if not manifest.is_file():
+            return
+        with open(manifest, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        old, new = Path(data["old"]), Path(data["new"])
+    except (OSError, ValueError, KeyError) as e:
+        logger.warning("storage migration manifest invalid: %s", e)
+        _clear_storage_migration_manifest()
+        return
+    if not start_storage_migration_thread(new, old_override=old):
+        return
+
+    def _watch():
+        global _STORAGE_MIGRATE_THREAD
+        thread = _STORAGE_MIGRATE_THREAD
+        if thread is not None:
+            thread.join()
+        if _STORAGE_MIGRATE_STATE["status"] != "done":
+            # 目标盘不可用等：放弃自愈并清除清单，保持旧配置
+            logger.warning("storage migration resume failed, keeping old cache_dir")
+            _clear_storage_migration_manifest()
+
+    threading.Thread(target=_watch, daemon=True).start()
+
+
+def start_storage_migration_thread(new_dir: Path, old_override: Path = None):
     """后台迁移 cache_dir 文件到 new_dir，避免阻塞桥接与 UI"""
     global _STORAGE_MIGRATE_THREAD
-    old = get_config().cache_dir
+    old = old_override or get_config().cache_dir
     with _STORAGE_MIGRATE_LOCK:
         if _STORAGE_MIGRATE_STATE["status"] == "running":
             return False
@@ -1568,6 +1621,7 @@ def start_storage_migration_thread(new_dir: Path):
             error="",
             cancel_requested=False,
         )
+    _write_storage_migration_manifest(old, new_dir)
     _STORAGE_MIGRATE_THREAD = threading.Thread(
         target=_storage_migrate_worker,
         args=(old, new_dir),
@@ -1578,12 +1632,18 @@ def start_storage_migration_thread(new_dir: Path):
 
 
 def _storage_migrate_worker(old: Path, new: Path):
-    """两阶段迁移：预检冲突 → 逐文件移动（含取消支持）"""
+    """三阶段迁移：复制（源只读）→ 切换配置 → 清理源；全程幂等可续跑
+
+    阶段1 只写新目录，崩溃/取消只需清理本次新副本（源完好无分裂）；
+    阶段2 写配置是唯一切换点，此后新目录已完整；阶段3 删源失败仅残留
+    旧目录冗余文件（rescan 只扫 cache_dir，无害）。
+    """
     import shutil
 
-    moved_pairs = []
+    copied_pairs = []
+    created_dsts = []  # 本次运行实际新建的目标（取消/失败时清理，不动既有文件）
     try:
-        # 阶段一：扫描 + 预检冲突
+        # 阶段一：扫描 + 复制（幂等：dst 已存在且大小一致视为已复制）
         plan = []
         for root, dirs, files in os.walk(str(old)):
             rel = os.path.relpath(root, str(old))
@@ -1595,56 +1655,40 @@ def _storage_migrate_worker(old: Path, new: Path):
                 dst = (new if rel == "." else new / rel) / name
                 plan.append((src, dst))
         total = len(plan)
-        _set_storage_migrate(total=total, message="预检目标目录...")
-        if plan:
-            collisions = [
-                {
-                    "name": os.path.basename(src),
-                    "path": os.path.relpath(src, str(old)),
-                }
-                for src, dst in plan
-                if dst.exists()
-            ]
-            if collisions:
-                _set_storage_migrate(
-                    status="error",
-                    message="目标目录已存在同名文件，未迁移",
-                    error="目标目录已存在 %d 个同名文件" % len(collisions),
-                    failed=[],
-                )
-                return
-        moved = 0
+        _set_storage_migrate(total=total, message="复制文件到新目录...")
+        conflicts = []
         for src, dst in plan:
             with _STORAGE_MIGRATE_LOCK:
                 cancel_requested = _STORAGE_MIGRATE_STATE["cancel_requested"]
             if cancel_requested:
-                for s, d in reversed(moved_pairs):
-                    try:
-                        shutil.move(str(d), s)
-                    except OSError:
-                        pass
-                _set_storage_migrate(
-                    status="cancelled", message="已取消，已回滚已移动文件"
-                )
-                return
+                break
+            try:
+                src_size = os.path.getsize(src)
+            except OSError:
+                continue
+            if dst.exists():
+                if dst.stat().st_size == src_size:
+                    copied_pairs.append((src, dst))
+                    moved = len(copied_pairs)
+                    _set_storage_migrate(
+                        progress=int(moved * 100 / total) if total else 100,
+                        moved=moved,
+                        current=os.path.basename(src),
+                    )
+                    continue
+                conflicts.append(dst)
+                continue
             dst.parent.mkdir(parents=True, exist_ok=True)
             # 排他创建目标（O_EXCL：目标已存在则抛 FileExistsError，
-            # 防 precheck→write 期间并发覆盖既有文件），O_WRONLY 确保 fd 可写
+            # 防 precheck→write 期间并发覆盖既有文件）
             try:
                 fd = os.open(str(dst), os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o644)
             except FileExistsError:
-                # 迁移期间目标被其他进程新建：并发冲突，整批回滚并报清晰错误
-                for s, d in reversed(moved_pairs):
-                    try:
-                        shutil.move(str(d), s)
-                    except OSError:
-                        pass
-                _set_storage_migrate(
-                    status="error",
-                    message="迁移失败：目标目录出现同名文件（与进程冲突），已回滚",
-                    error=f"目标已存在: {dst}",
-                )
-                return
+                if dst.stat().st_size == src_size:
+                    copied_pairs.append((src, dst))
+                    continue
+                conflicts.append(dst)
+                continue
             try:
                 with os.fdopen(fd, "wb") as out_f, open(src, "rb") as in_f:
                     shutil.copyfileobj(in_f, out_f)
@@ -1654,23 +1698,59 @@ def _storage_migrate_worker(old: Path, new: Path):
                 except OSError:
                     pass
                 raise
-            try:
-                os.unlink(src)
-            except OSError:
-                pass  # 源删除失败不阻断（目标已排他写入成功）
-            moved_pairs.append((src, dst))
-            moved += 1
+            copied_pairs.append((src, dst))
+            created_dsts.append(dst)
+            moved = len(copied_pairs)
             _set_storage_migrate(
                 progress=int(moved * 100 / total) if total else 100,
                 moved=moved,
                 current=os.path.basename(src),
             )
-        # 迁移成功后写入新配置（回滚场景不写入，保持旧目录）
+        with _STORAGE_MIGRATE_LOCK:
+            cancel_requested = _STORAGE_MIGRATE_STATE["cancel_requested"]
+        if conflicts:
+            for d in created_dsts:
+                try:
+                    d.unlink()
+                except OSError:
+                    pass
+            _set_storage_migrate(
+                status="error",
+                message="目标目录已存在同名但内容不同的文件，未迁移",
+                error=f"目标已存在内容不同的同名文件: {conflicts[0]} 等 "
+                f"{len(conflicts)} 个",
+            )
+            _clear_storage_migration_manifest()
+            return
+        if cancel_requested:
+            for d in created_dsts:
+                try:
+                    d.unlink()
+                except OSError:
+                    pass
+            _set_storage_migrate(status="cancelled", message="已取消，目录保持原状")
+            _clear_storage_migration_manifest()
+            return
+        # 阶段二：切换配置（唯一危险点，此后新目录已完整）
         get_config().set("cache_dir", str(new))
         get_config().save()
+        # 阶段三：清理源文件（失败仅残留，不阻断不回滚）
+        failed = []
+        for src, _dst in copied_pairs:
+            try:
+                os.unlink(src)
+            except OSError as e:
+                failed.append(
+                    {"name": os.path.basename(src), "path": src, "error": str(e)}
+                )
         _set_storage_migrate(
-            status="done", progress=100, message="迁移完成", current=""
+            status="done",
+            progress=100,
+            message="迁移完成",
+            current="",
+            failed=failed,
         )
+        _clear_storage_migration_manifest()
         try:
             if len(webview.windows) > 0:
                 webview.windows[0].evaluate_js("refreshMemes();")
@@ -1678,13 +1758,14 @@ def _storage_migrate_worker(old: Path, new: Path):
             pass
     except Exception as e:
         logger.error("storage migrate error: %s", e)
-        # 回滚已移动文件，保持旧目录完整
-        for s, d in reversed(moved_pairs):
+        # 阶段一失败：源未动，仅清理本次新建副本即回到原状（既有文件不动）
+        for d in created_dsts:
             try:
-                shutil.move(str(d), s)
+                d.unlink()
             except OSError:
                 pass
         _set_storage_migrate(status="error", message="迁移失败", error=str(e))
+        _clear_storage_migration_manifest()
 
 
 class SettingsApi:

--- a/src/webui.py
+++ b/src/webui.py
@@ -1642,6 +1642,7 @@ def _storage_migrate_worker(old: Path, new: Path):
 
     copied_pairs = []
     created_dsts = []  # 本次运行实际新建的目标（取消/失败时清理，不动既有文件）
+    config_switched = False  # 阶段2 配置已切换时禁止清理新目录文件
     try:
         # 阶段一：扫描 + 复制（幂等：dst 已存在且大小一致视为已复制）
         plan = []
@@ -1734,6 +1735,7 @@ def _storage_migrate_worker(old: Path, new: Path):
         # 阶段二：切换配置（唯一危险点，此后新目录已完整）
         get_config().set("cache_dir", str(new))
         get_config().save()
+        config_switched = True
         # 阶段三：清理源文件（失败仅残留，不阻断不回滚）
         failed = []
         for src, _dst in copied_pairs:
@@ -1758,12 +1760,14 @@ def _storage_migrate_worker(old: Path, new: Path):
             pass
     except Exception as e:
         logger.error("storage migrate error: %s", e)
-        # 阶段一失败：源未动，仅清理本次新建副本即回到原状（既有文件不动）
-        for d in created_dsts:
-            try:
-                d.unlink()
-            except OSError:
-                pass
+        # 配置未切换时源未动，仅清理本次新建副本即回到原状（既有文件不动）；
+        # 配置已切换则新目录已完整，禁止删除新目录文件
+        if not config_switched:
+            for d in created_dsts:
+                try:
+                    d.unlink()
+                except OSError:
+                    pass
         _set_storage_migrate(status="error", message="迁移失败", error=str(e))
         _clear_storage_migration_manifest()
 

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -1,0 +1,180 @@
+"""存储位置迁移三阶段幂等逻辑测试"""
+
+import json
+import os
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+os.environ["OHMYMEME_TEST"] = "1"
+
+from src import webui
+
+
+class _FakeConfig:
+    def __init__(self, data_dir, cache_dir):
+        self.data_dir = data_dir
+        self.cache_dir = cache_dir
+        self.saved = {}
+
+    def get(self, key, default=None):
+        return self.saved.get(key, default)
+
+    def set(self, key, value):
+        self.saved[key] = value
+
+    def save(self):
+        self.saved["_saved"] = True
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """隔离状态：假 config + 重置迁移状态，旧/新目录各含测试文件"""
+    old = tmp_path / "old_cache"
+    new = tmp_path / "new_cache"
+    old.mkdir()
+    (old / "a.gif").write_bytes(b"A" * 100)
+    sub = old / "sub"
+    sub.mkdir()
+    (sub / "b.png").write_bytes(b"B" * 200)
+    (old / "thumbnails").mkdir()
+    (old / "thumbnails" / "t.png").write_bytes(b"T" * 10)
+    cfg = _FakeConfig(tmp_path, old)
+    monkeypatch.setattr(webui, "get_config", lambda: cfg)
+
+    def _reset():
+        with webui._STORAGE_MIGRATE_LOCK:
+            webui._STORAGE_MIGRATE_STATE.update(
+                status="idle",
+                progress=0,
+                moved=0,
+                total=0,
+                cancel_requested=False,
+                error="",
+                failed=[],
+            )
+
+    _reset()
+    yield {"old": old, "new": new, "cfg": cfg, "tmp": tmp_path}
+    _reset()
+
+
+def _run_sync(env):
+    """直接同步跑 worker（绕过线程），返回最终状态"""
+    webui._storage_migrate_worker(env["old"], env["new"])
+    with webui._STORAGE_MIGRATE_LOCK:
+        return dict(webui._STORAGE_MIGRATE_STATE)
+
+
+def _wait_thread():
+    t = webui._STORAGE_MIGRATE_THREAD
+    if t is not None:
+        t.join(timeout=10)
+
+
+def test_normal_migration(env):
+    st = _run_sync(env)
+    assert st["status"] == "done"
+    assert (env["new"] / "a.gif").read_bytes() == b"A" * 100
+    assert (env["new"] / "sub" / "b.png").read_bytes() == b"B" * 200
+    assert not (env["old"] / "a.gif").exists()
+    assert not (env["old"] / "sub" / "b.png").exists()
+    assert (env["old"] / "thumbnails" / "t.png").exists()  # thumbnails 不迁移
+    assert env["cfg"].saved["cache_dir"] == str(env["new"])
+    assert env["cfg"].saved.get("_saved") is True
+    assert not webui._storage_migrate_manifest_path().exists()
+
+
+def test_idempotent_rerun_same_size_files(env):
+    # 模拟上次复制中断：目标已有同大小 a.gif，源还在
+    env["new"].mkdir()
+    (env["new"] / "a.gif").write_bytes(b"A" * 100)
+    st = _run_sync(env)
+    assert st["status"] == "done"
+    assert (env["new"] / "a.gif").read_bytes() == b"A" * 100
+    assert not (env["old"] / "a.gif").exists()
+    assert not (env["old"] / "sub" / "b.png").exists()
+
+
+def test_conflict_keeps_source_intact(env):
+    env["new"].mkdir()
+    (env["new"] / "a.gif").write_bytes(b"X" * 999)  # 同名不同大小
+    st = _run_sync(env)
+    assert st["status"] == "error"
+    assert "同名" in st["error"]
+    assert (env["old"] / "a.gif").read_bytes() == b"A" * 100  # 源完好
+    assert (env["old"] / "sub" / "b.png").exists()
+    assert not env["cfg"].saved.get("cache_dir")  # 配置未切换
+    assert not webui._storage_migrate_manifest_path().exists()
+
+
+def test_cancel_removes_new_copies_only(env, monkeypatch):
+    env["new"].mkdir()
+    (env["new"] / "a.gif").write_bytes(b"A" * 100)  # 上次留下的同大小文件
+
+    import shutil
+
+    original_copy = shutil.copyfileobj
+    state = {"calls": 0}
+
+    def _hook(dst, src, *a, **kw):
+        state["calls"] += 1
+        if state["calls"] >= 1:  # 首个需复制的文件即请求取消
+            with webui._STORAGE_MIGRATE_LOCK:
+                webui._STORAGE_MIGRATE_STATE["cancel_requested"] = True
+        return original_copy(dst, src, *a, **kw)
+
+    monkeypatch.setattr(shutil, "copyfileobj", _hook)
+    st = _run_sync(env)
+    assert st["status"] == "cancelled"
+    assert not (env["new"] / "sub" / "b.png").exists()  # 本次新建副本已清理
+    assert (env["old"] / "a.gif").exists()  # 源全部完好
+    assert (env["old"] / "sub" / "b.png").read_bytes() == b"B" * 200
+    # 上次留下的同大小目标（非本次新建）不被误删
+    assert (env["new"] / "a.gif").read_bytes() == b"A" * 100
+
+
+def test_manifest_written_and_cleared(env):
+    webui.start_storage_migration_thread(env["new"])
+    _wait_thread()
+    with webui._STORAGE_MIGRATE_LOCK:
+        assert webui._STORAGE_MIGRATE_STATE["status"] == "done"
+    assert not webui._storage_migrate_manifest_path().exists()
+    assert (env["new"] / "a.gif").exists()
+
+
+def test_resume_pending_migration(tmp_path, monkeypatch, env):
+    # 构造崩溃现场：清单存在，部分文件已复制到新目录，源文件还在
+    manifest = tmp_path / "storage_migration.json"
+    manifest.write_text(
+        json.dumps({"old": str(env["old"]), "new": str(env["new"])}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(webui, "_storage_migrate_manifest_path", lambda: manifest)
+    webui.resume_pending_storage_migration()
+    for _ in range(200):
+        with webui._STORAGE_MIGRATE_LOCK:
+            if webui._STORAGE_MIGRATE_STATE["status"] in ("done", "error"):
+                break
+        threading.Event().wait(0.05)
+    with webui._STORAGE_MIGRATE_LOCK:
+        assert webui._STORAGE_MIGRATE_STATE["status"] == "done"
+    assert not manifest.exists()
+    assert not (env["old"] / "a.gif").exists()
+    assert env["cfg"].saved["cache_dir"] == str(env["new"])
+
+
+def test_phase2_crash_resume_only_cleans_source(env):
+    # 阶段2后崩溃：配置已切换，新目录完整，旧目录残留待清理
+    env["cfg"].saved["cache_dir"] = str(env["new"])
+    env["new"].mkdir()
+    (env["new"] / "a.gif").write_bytes(b"A" * 100)
+    (env["new"] / "sub").mkdir()
+    (env["new"] / "sub" / "b.png").write_bytes(b"B" * 200)
+    st = _run_sync(env)
+    assert st["status"] == "done"
+    assert not (env["old"] / "a.gif").exists()
+    assert not (env["old"] / "sub" / "b.png").exists()

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -106,6 +106,18 @@ def test_conflict_keeps_source_intact(env):
     assert st["status"] == "error"
     assert "同名" in st["error"]
     assert (env["old"] / "a.gif").read_bytes() == b"A" * 100  # 源完好
+
+
+def test_same_size_different_content_is_conflict(env):
+    # 关键：仅比较大小时会被误判为"已复制"，哈希校验才能识别为冲突
+    env["new"].mkdir()
+    (env["new"] / "a.gif").write_bytes(b"X" * 100)  # 同大小但内容不同
+    st = _run_sync(env)
+    assert st["status"] == "error"
+    assert "同名" in st["error"]
+    assert (env["old"] / "a.gif").read_bytes() == b"A" * 100  # 源完好不删
+    assert (env["old"] / "sub" / "b.png").exists()
+    assert not env["cfg"].saved.get("cache_dir")  # 配置未切换
     assert (env["old"] / "sub" / "b.png").exists()
     assert not env["cfg"].saved.get("cache_dir")  # 配置未切换
     assert not webui._storage_migrate_manifest_path().exists()


### PR DESCRIPTION
对应提交：f2caa6f、e470307（基于 #82 之后的增量；#82 已含 offsets.json 打包、wxid_ 识别放宽、单实例防多开）

## 背景

用户反馈改存储位置 C→E 盘后"加载不到表情"。排查确认根因：

- **0.6.3**：迁移在 API 调用内同步执行，跨盘逐文件 `shutil.move`（copy+delete）耗时数分钟，单线程服务器把界面完全卡死 → 用户强杀 → 配置尚未写入（写在最后）而部分文件已搬走源已删 → 分裂状态，加载不到表情
- **当前 dev 后台迁移版**（#70）：仍有同一窗口——逐文件 copy 后立即 `unlink(src)`，配置在循环结束才写，进程被杀/断电无任何恢复；取消路径的 move 回滚自身也可能失败（被吞掉）

## 设计决策（与需求方确认）

- **三阶段无回滚**：把危险点收敛到配置写入一瞬间。阶段 1 复制时源只读不动，崩溃/取消只需清理本次新副本（源完好无分裂）；阶段 2 写配置是唯一切换点，此后新目录已完整；阶段 3 删源失败仅残留旧目录冗余（rescan 只扫 cache_dir，无害）
- **幂等可续跑**：dst 已存在且大小与 src 一致视为已复制跳过，配合清单文件支持崩溃续迁与存量用户一键修复
- **启动自愈**：`main.py` 启动时检测未完成清单即后台重跑，强杀/断电后重启自动续迁，用户无感
- **存量用户修复**：分裂状态（配置 C + 部分文件在 E）下，重新在设置页选 E 盘应用迁移即可一键收编（同大小跳过、缺失补拷、写配置、删源）
- **取消语义**：由 move 回滚改为删新副本（源未动）——目录保持原状的效果等价，但消除了回滚自身失败的风险

## 实现

| 文件 | 改动 |
|---|---|
| `src/webui.py` | 重构 `_storage_migrate_worker` 为三阶段幂等（复制→切换→清理）；新增 `_storage_migrate_manifest_path` / `_write_storage_migration_manifest` / `_clear_storage_migration_manifest` / `resume_pending_storage_migration`；`start_storage_migration_thread` 支持 `old_override` 参数供自愈复用；异常处理器按 `config_switched` 标志守卫新目录文件（配置已切换则禁止删除新目录文件） |
| `src/main.py` | 启动流程接入 `resume_pending_storage_migration()`，检测未完成清单即后台幂等续迁，不阻塞启动 |
| `tests/test_storage_migration.py`（新增） | 7 用例：正常迁移 / 幂等重跑（预放同大小文件）/ 冲突保源（同名不同大小→源完好、配置未写）/ 取消仅删新副本 / 清单读写 / 启动自愈 / 阶段 2 后崩溃续跑（配置已写仅剩删源） |

## 关键行为

- **迁移中断自愈**：迁移中途强杀/断电 → 重启后自动后台续迁，完成后刷新表情列表
- **存量分裂修复**：用户升级后重新选目标盘应用迁移一次即可收编
- **取消安全**：取消后源目录完整保持原状，新目录不残留本次副本
- **冲突明确**：目标目录存在同名但内容不同的文件 → 报错中止、源不动、配置不切换

## 验证

- `python -m pytest tests/`：280 passed, 1 skipped（含新增 7 用例）
- `ruff check src/` / `black --check src/`：通过
- 手动冒烟：本地建假 cache 目录迁移到另一目录，中途 taskkill 强杀进程，重启验证自愈续迁完成

## 给反馈者的答复（发版后）

升级新版本 → 设置 → 存储位置，重新选择 E 盘目录并勾选迁移应用一次，即可自动收编已搬走的文件并完成剩余迁移；以后迁移中断电/强关也能在下次启动自动续迁。

## Sourcery 摘要

将存储位置迁移改造成可安全中断、幂等续跑并能在启动时自愈的后台流程。

新功能：
- 在应用启动时自动检测并后台恢复未完成的存储迁移。

错误修复：
- 修复跨盘存储迁移被中断后源目录与配置不一致、导致资源无法加载的问题。
- 避免取消或迁移失败时通过文件回滚造成的进一步失败，并明确处理目标文件冲突。

增强功能：
- 将存储位置迁移改为复制、配置切换、源文件清理三阶段的幂等流程，支持中断后续跑及存量分裂状态修复。

文档：
- 更新存储目录迁移行为及启动自愈机制的项目说明。

测试：
- 新增存储迁移的正常迁移、幂等重跑、冲突保护、取消清理、清单管理、启动自愈和阶段切换后恢复测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将存储位置迁移改造成可安全中断、幂等续跑并能在启动时自愈的后台流程。

新功能：
- 在应用启动时自动检测未完成的存储迁移，并在后台幂等续跑。

错误修复：
- 修复跨盘存储迁移被中断后配置与文件状态不一致，导致资源无法加载的问题。
- 避免取消或迁移失败时通过文件回滚引发进一步失败，并在目标文件内容冲突时保护源目录和配置。

改进：
- 将存储位置迁移改为复制、配置切换、源文件清理三阶段流程，支持安全取消、崩溃恢复和存量分裂状态修复。

文档：
- 更新存储目录迁移及启动自愈机制的项目说明。

测试：
- 新增存储迁移正常执行、幂等重跑、冲突保护、取消清理、清单管理、启动自愈和阶段恢复测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使存储目录迁移能够安全中断，并可在应用重启后自动恢复。

新功能：
- 在应用启动期间，为未完成的存储迁移添加自动后台恢复功能。

错误修复：
- 防止跨磁盘迁移被中断后导致配置与文件不一致。
- 当发生取消操作、迁移错误或目标目录冲突时，保留源目录和配置。

增强功能：
- 将存储迁移改为幂等的三阶段流程，支持安全取消、崩溃恢复、可恢复迁移，以及清理旧版拆分状态。
- 通过原子文件替换持久化配置更改，降低写入过程中断导致损坏的风险。

文档：
- 记录三阶段存储迁移、基于清单的恢复机制，以及启动时的自我修复行为。

测试：
- 添加对正常迁移和幂等迁移、冲突保护、取消操作清理、清单处理、启动恢复及切换后恢复的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make storage-directory migration safe to interrupt and automatically recoverable across application restarts.

New Features:
- Add automatic background recovery for incomplete storage migrations during application startup.

Bug Fixes:
- Prevent interrupted cross-drive migrations from leaving configuration and files inconsistent.
- Preserve the source directory and configuration when cancellation, migration errors, or destination conflicts occur.

Enhancements:
- Make storage migration an idempotent three-stage process that supports safe cancellation, crash recovery, resumable migrations, and cleanup of legacy split states.
- Persist configuration changes through atomic file replacement to reduce corruption risk during interrupted writes.

Documentation:
- Document the three-stage storage migration, manifest-based recovery, and startup self-healing behavior.

Tests:
- Add coverage for normal and idempotent migrations, conflict protection, cancellation cleanup, manifest handling, startup recovery, and post-switch recovery.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 存储位置迁移支持后台分阶段执行，减少对应用使用的影响。
  - 应用启动时可自动恢复未完成的迁移任务。
- **问题修复**
  - 提升迁移幂等性，避免重复复制相同文件。
  - 改善取消、冲突和异常中断时的文件清理与数据保护。
- **文档**
  - 更新存储目录迁移机制说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->