### PR TITLE
fix(ui): 设置页对话框覆盖问题 + 高频热键卡死 + 对话框统一修复

### DIFF
--- a/src/webui.py
+++ b/src/webui.py
@@ -2324,17 +2324,34 @@ class SettingsApi:
             "total_size": total,
         }
 
-    def pick_storage_dir(self):
-        """选择新的表情包存储目录（只返回路径，不立即生效）"""
+    def _pick_folder(self, title: str = "选择文件夹") -> str:
+        """以设置窗口为 owner 打开目录选择对话框，返回路径或空串（取消/失败）"""
+        win = self._webui._settings_window
+        if win is None:
+            win = webview.windows[0] if webview.windows else None
+        if win is None:
+            return ""
         try:
-            result = webview.windows[0].create_file_dialog(
+            result = win.create_file_dialog(
                 webview.FileDialog.FOLDER, allow_multiple=False
             )
         except Exception:
-            return {"ok": False, "error": "dialog failed"}
+            return ""
         if not result:
-            return {"ok": False, "cancelled": True}
+            return ""
         path = result[0] if isinstance(result, (tuple, list)) else result
+        # 对话框关闭后焦点可能回到主窗口，恢复设置窗口到前台
+        try:
+            self._webui.focus_settings_window()
+        except Exception:
+            pass
+        return path
+
+    def pick_storage_dir(self):
+        """选择新的表情包存储目录（只返回路径，不立即生效）"""
+        path = self._pick_folder()
+        if not path:
+            return {"ok": False, "cancelled": True}
         return {"ok": True, "path": path}
 
     def apply_storage_dir(self, path, move_files=False):
@@ -3229,6 +3246,8 @@ class WebUI:
         self._started = False
         self._pending_hide = False
         self._hotkey_session = False
+        self._last_toggle_ms = 0
+        self._window_state_lock = threading.Lock()
         self._on_hotkey_change_cb = None
         self._update_debug = update_debug
         self._silent_start = silent_start
@@ -3324,47 +3343,82 @@ class WebUI:
 
     # 显示主窗口并清理非热键会话状态
     def show(self):
-        self._visible = True
-        self._hotkey_session = False
-        if self._window:
-            try:
-                self._window.on_top = True  # 置顶一下提升 z-order，随即复位不长期置顶
-                self._window.on_top = False
-                if callable(self._window.show):
-                    self._window.show()
-                if callable(self._window.focus):
-                    self._window.focus()
-                self._window.evaluate_js("focusSearch()")
-            except Exception as e:
-                logger.warning(f"show window error: {e}")
+        with self._window_state_lock:
+            self._visible = True
+            self._hotkey_session = False
+        self._do_show()
+
+    def _do_show(self):
+        if self._window is None:
+            return
+        if threading.current_thread() is threading.main_thread():
+            self._show_on_gui()
+        else:
+            self._run_on_gui(0, self._show_on_gui)
+
+    def _show_on_gui(self):
+        if self._window is None:
+            return
+        try:
+            self._window.on_top = True  # 置顶一下提升 z-order，随即复位不长期置顶
+            self._window.on_top = False
+            if callable(self._window.show):
+                self._window.show()
+            if callable(self._window.focus):
+                self._window.focus()
+            self._window.evaluate_js("focusSearch()")
+        except Exception:
+            pass
 
     def hide(self):
-        self._visible = False
-        self._hotkey_session = False
-        if self._window:
-            try:
-                self._save_window_position()
-                if callable(self._window.hide):
-                    self._window.hide()
-            except Exception as e:
-                logger.warning(f"hide window error: {e}")
+        with self._window_state_lock:
+            self._visible = False
+            self._hotkey_session = False
+        self._do_hide()
+
+    def _do_hide(self):
+        if self._window is None:
+            return
+        if threading.current_thread() is threading.main_thread():
+            self._hide_on_gui()
+        else:
+            self._run_on_gui(0, self._hide_on_gui)
+
+    def _hide_on_gui(self):
+        if self._window is None:
+            return
+        try:
+            self._save_window_position()
+            if callable(self._window.hide):
+                self._window.hide()
+        except Exception:
+            pass
 
     def toggle(self):
-        if self._visible:
+        with self._window_state_lock:
+            visible = self._visible
+        if visible:
             self.hide()
         else:
             self.show()
 
     def toggle_safe(self):
-        # show/hide 底层为 Invoke 调度，任意线程调用均安全
         if self._window:
             self.toggle()
 
+    _HOTKEY_DEBOUNCE_S = 0.25
+
     def toggle_hotkey_safe(self):
-        """按热键专用定位规则安全切换窗口"""
+        """按热键专用定位规则安全切换窗口（去抖 + 持锁）"""
         if not self._window:
             return
-        if self._visible:
+        now = time.monotonic()
+        with self._window_state_lock:
+            if now - self._last_toggle_ms < self._HOTKEY_DEBOUNCE_S:
+                return
+            self._last_toggle_ms = now
+            visible = self._visible
+        if visible:
             self.hide()
             return
         if self._cfg.get("hotkey_show_at_mouse", False):
@@ -3372,23 +3426,27 @@ class WebUI:
                 position = self._get_hotkey_window_position()
                 if position is not None:
                     self._window.move(*position)
-            except Exception as e:
-                logger.warning("hotkey window move error: %s", e)
+            except Exception:
+                pass
         self.show()
-        self._hotkey_session = True
+        with self._window_state_lock:
+            self._hotkey_session = True
 
     def schedule_hide(self):
-        if not self._hotkey_session:
-            return False
-        self._pending_hide = True
+        with self._window_state_lock:
+            if not self._hotkey_session:
+                return False
+            self._pending_hide = True
         if self._window:
             self._run_on_gui(0.1, self._process_pending_hide)
         return True
 
     def _process_pending_hide(self):
-        if self._pending_hide:
+        with self._window_state_lock:
+            if not self._pending_hide:
+                return
             self._pending_hide = False
-            self.hide()
+        self.hide()
 
     def _run_on_gui(self, delay: float, func):
         """延时在 GUI 线程执行（pywebview Window 无 after 方法）"""
@@ -3984,6 +4042,21 @@ class WebUI:
         except Exception as e:
             logger.warning(f"create settings window error: {e}")
             return False
+
+    def focus_settings_window(self):
+        """把设置窗口重新拉到前台（对话框关闭后恢复焦点用）"""
+        win = self._settings_window
+        if win is None:
+            return
+        try:
+            win.on_top = True  # 置顶一下提升 z-order，随即复位不长期置顶
+            win.on_top = False
+            if callable(win.show):
+                win.show()
+            if callable(win.focus):
+                win.focus()
+        except Exception:
+            pass
 
     def close_settings(self):
         if self._settings_window:

--- a/src/webui.py
+++ b/src/webui.py
@@ -1060,14 +1060,11 @@ class JsApi:
 
     def import_memes(self) -> bool:
         # 通过系统文件对话框选择导入（后台执行，避免大数量导入阻塞界面）
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.OPEN,
-                allow_multiple=True,
-                file_types=("图片文件 (*.png;*.jpg;*.jpeg;*.gif;*.webp;*.bmp)",),
-            )
-        except Exception:
-            return {"ok": False}
+        result = self._dialog(
+            webview.FileDialog.OPEN,
+            allow_multiple=True,
+            file_types=("图片文件 (*.png;*.jpg;*.jpeg;*.gif;*.webp;*.bmp)",),
+        )
         if not result:
             return {"ok": False, "cancelled": True}
         paths = list(result)
@@ -1077,12 +1074,7 @@ class JsApi:
 
     def import_folder(self, make_collection=True) -> dict:
         """选择文件夹并导入其中全部图片；make_collection 时以文件夹名创建分组"""
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.FOLDER, allow_multiple=False
-            )
-        except Exception:
-            return {"ok": False, "error": "无法打开目录选择对话框"}
+        result = self._dialog(webview.FileDialog.FOLDER)
         if not result:
             return {"ok": False, "cancelled": True}
         folder = result[0] if isinstance(result, (tuple, list)) else result
@@ -2059,14 +2051,11 @@ class SettingsApi:
         st = adb_util.get_qq_progress()
         if st["status"] != "done" or not st["zip_path"]:
             return {"ok": False, "error": "no zip ready"}
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.SAVE,
-                allow_multiple=False,
-                file_types=("ZIP 文件 (*.zip)",),
-            )
-        except Exception:
-            return {"ok": False, "error": "dialog failed"}
+        result = self._dialog(
+            webview.FileDialog.SAVE,
+            allow_multiple=False,
+            file_types=("ZIP 文件 (*.zip)",),
+        )
         if not result:
             return {"ok": False, "error": "cancelled"}
         import shutil
@@ -2092,21 +2081,12 @@ class SettingsApi:
 
     def export_logs(self) -> dict:
         """导出本次运行收集的日志（DEBUG 级）到用户选择的位置"""
-        win = self._webui._settings_window or (
-            webview.windows[0] if webview.windows else None
+        result = self._dialog(
+            webview.FileDialog.SAVE,
+            allow_multiple=False,
+            save_filename="OhMyMeme-logs.txt",
+            file_types=("文本文件 (*.txt)",),
         )
-        if not win:
-            return {"ok": False, "error": "no window"}
-        try:
-            result = win.create_file_dialog(
-                webview.FileDialog.SAVE,
-                allow_multiple=False,
-                save_filename="OhMyMeme-logs.txt",
-                file_types=("文本文件 (*.txt)",),
-            )
-        except Exception as e:
-            logger.warning(f"export_logs dialog error: {e!r}")
-            return {"ok": False, "error": "dialog failed"}
         if not result:
             return {"ok": False, "error": "cancelled"}
         dst = result[0] if isinstance(result, (tuple, list)) else result
@@ -2135,12 +2115,7 @@ class SettingsApi:
 
     def pick_tg_tdata(self) -> dict:
         """手动选择 Telegram Desktop tdata 目录（校验并持久化）"""
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.FOLDER, allow_multiple=False
-            )
-        except Exception:
-            return {"ok": False, "error": "无法打开目录选择对话框"}
+        result = self._dialog(webview.FileDialog.FOLDER)
         if not result:
             return {"ok": False, "cancelled": True}
         path = result[0] if isinstance(result, (tuple, list)) else result
@@ -2194,12 +2169,7 @@ class SettingsApi:
 
     def pick_wechat_root(self):
         """手动选择微信文件根目录"""
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.FOLDER, allow_multiple=False
-            )
-        except Exception:
-            return {"ok": False, "error": "无法打开目录选择对话框"}
+        result = self._dialog(webview.FileDialog.FOLDER)
         if not result:
             return {"ok": False, "cancelled": True}
         path = result[0] if isinstance(result, (tuple, list)) else result
@@ -2252,14 +2222,11 @@ class SettingsApi:
 
     def qqnt_pick_ini(self) -> dict:
         """选择 UserDataInfo.ini，保存到配置并返回环境状态"""
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.OPEN,
-                allow_multiple=False,
-                file_types=("INI Files (*.ini);;All Files (*)",),
-            )
-        except Exception:
-            return {"ok": False}
+        result = self._dialog(
+            webview.FileDialog.OPEN,
+            allow_multiple=False,
+            file_types=("INI Files (*.ini);;All Files (*)",),
+        )
         if not result:
             return {"ok": False, "cancelled": True}
         path = result[0] if isinstance(result, (tuple, list)) else result
@@ -2270,12 +2237,7 @@ class SettingsApi:
 
     def qqnt_pick_userdata(self) -> dict:
         """选择用户数据目录，保存到配置并返回环境状态"""
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.FOLDER, allow_multiple=False
-            )
-        except Exception:
-            return {"ok": False}
+        result = self._dialog(webview.FileDialog.FOLDER)
         if not result:
             return {"ok": False, "cancelled": True}
         path = result[0] if isinstance(result, (tuple, list)) else result
@@ -2285,12 +2247,7 @@ class SettingsApi:
 
     def qqnt_pick_base(self) -> dict:
         """选择保存基础目录"""
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.FOLDER, allow_multiple=False
-            )
-        except Exception:
-            return {"ok": False}
+        result = self._dialog(webview.FileDialog.FOLDER)
         if not result:
             return {"ok": False, "cancelled": True}
         path = result[0] if isinstance(result, (tuple, list)) else result
@@ -2324,34 +2281,35 @@ class SettingsApi:
             "total_size": total,
         }
 
-    def _pick_folder(self, title: str = "选择文件夹") -> str:
-        """以设置窗口为 owner 打开目录选择对话框，返回路径或空串（取消/失败）"""
+    def _dialog(self, kind, **kw):
+        """以设置窗口为 owner 打开文件对话框，返回原始 result（None 表示取消/失败）。
+
+        对话框关闭后自动恢复设置窗口前台焦点，避免主窗口抢焦遮挡设置页。
+        kind: webview.FileDialog.FOLDER / OPEN / SAVE
+        其余关键字透传给 create_file_dialog。
+        """
         win = self._webui._settings_window
         if win is None:
             win = webview.windows[0] if webview.windows else None
         if win is None:
-            return ""
+            return None
         try:
-            result = win.create_file_dialog(
-                webview.FileDialog.FOLDER, allow_multiple=False
-            )
+            result = win.create_file_dialog(kind, **kw)
         except Exception:
-            return ""
-        if not result:
-            return ""
-        path = result[0] if isinstance(result, (tuple, list)) else result
+            return None
         # 对话框关闭后焦点可能回到主窗口，恢复设置窗口到前台
         try:
             self._webui.focus_settings_window()
         except Exception:
             pass
-        return path
+        return result
 
     def pick_storage_dir(self):
         """选择新的表情包存储目录（只返回路径，不立即生效）"""
-        path = self._pick_folder()
-        if not path:
+        result = self._dialog(webview.FileDialog.FOLDER)
+        if not result:
             return {"ok": False, "cancelled": True}
+        path = result[0] if isinstance(result, (tuple, list)) else result
         return {"ok": True, "path": path}
 
     def apply_storage_dir(self, path, move_files=False):
@@ -2412,12 +2370,7 @@ class SettingsApi:
 
     def backup_pick_dir(self) -> dict:
         """选择备份输出目录并立即生效"""
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.FOLDER, allow_multiple=False
-            )
-        except Exception:
-            return {"ok": False, "error": "dialog failed"}
+        result = self._dialog(webview.FileDialog.FOLDER)
         if not result:
             return {"ok": False, "cancelled": True}
         path = result[0] if isinstance(result, (tuple, list)) else result
@@ -2447,14 +2400,11 @@ class SettingsApi:
 
     def backup_pick_zip(self) -> dict:
         """选择要恢复的备份 ZIP 文件"""
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.OPEN,
-                allow_multiple=False,
-                file_types=("备份包 (*.zip)",),
-            )
-        except Exception:
-            return {"ok": False, "error": "dialog failed"}
+        result = self._dialog(
+            webview.FileDialog.OPEN,
+            allow_multiple=False,
+            file_types=("备份包 (*.zip)",),
+        )
         if not result:
             return {"ok": False, "cancelled": True}
         path = result[0] if isinstance(result, (tuple, list)) else result
@@ -2529,14 +2479,11 @@ class SettingsApi:
             return False
 
     def import_memes(self) -> dict:
-        try:
-            result = webview.windows[0].create_file_dialog(
-                webview.FileDialog.OPEN,
-                allow_multiple=True,
-                file_types=("图片文件 (*.png;*.jpg;*.jpeg;*.gif;*.webp;*.bmp)",),
-            )
-        except Exception:
-            return {"ok": False}
+        result = self._dialog(
+            webview.FileDialog.OPEN,
+            allow_multiple=True,
+            file_types=("图片文件 (*.png;*.jpg;*.jpeg;*.gif;*.webp;*.bmp)",),
+        )
         if not result:
             return {"ok": False, "cancelled": True}
         r = self._webui._do_import(result)

--- a/src/webui.py
+++ b/src/webui.py
@@ -3300,22 +3300,16 @@ class WebUI:
 
     # 显示主窗口并清理非热键会话状态
     def show(self):
+        """显示主窗口（线程安全：持锁完成状态更新 + 原生窗口操作）"""
+        if self._window is None:
+            return
         with self._window_state_lock:
             self._visible = True
             self._hotkey_session = False
-        self._do_show()
-
-    def _do_show(self):
-        if self._window is None:
-            return
-        if threading.current_thread() is threading.main_thread():
             self._show_on_gui()
-        else:
-            self._run_on_gui(0, self._show_on_gui)
 
     def _show_on_gui(self):
-        if self._window is None:
-            return
+        """必须在 _window_state_lock 内调用（状态与窗口操作原子化）"""
         try:
             self._window.on_top = True  # 置顶一下提升 z-order，随即复位不长期置顶
             self._window.on_top = False
@@ -3328,22 +3322,16 @@ class WebUI:
             pass
 
     def hide(self):
+        """隐藏主窗口（线程安全：持锁完成状态更新 + 原生窗口操作）"""
+        if self._window is None:
+            return
         with self._window_state_lock:
             self._visible = False
             self._hotkey_session = False
-        self._do_hide()
-
-    def _do_hide(self):
-        if self._window is None:
-            return
-        if threading.current_thread() is threading.main_thread():
             self._hide_on_gui()
-        else:
-            self._run_on_gui(0, self._hide_on_gui)
 
     def _hide_on_gui(self):
-        if self._window is None:
-            return
+        """必须在 _window_state_lock 内调用（状态与窗口操作原子化）"""
         try:
             self._save_window_position()
             if callable(self._window.hide):
@@ -3366,7 +3354,7 @@ class WebUI:
     _HOTKEY_DEBOUNCE_S = 0.25
 
     def toggle_hotkey_safe(self):
-        """按热键专用定位规则安全切换窗口（去抖 + 持锁）"""
+        """按热键专用定位规则安全切换窗口（去抖 + 持锁 + 状态与窗口操作原子化）"""
         if not self._window:
             return
         now = time.monotonic()
@@ -3375,18 +3363,20 @@ class WebUI:
                 return
             self._last_toggle_ms = now
             visible = self._visible
-        if visible:
-            self.hide()
-            return
-        if self._cfg.get("hotkey_show_at_mouse", False):
-            try:
-                position = self._get_hotkey_window_position()
-                if position is not None:
-                    self._window.move(*position)
-            except Exception:
-                pass
-        self.show()
-        with self._window_state_lock:
+            if visible:
+                self._visible = False
+                self._hide_on_gui()
+                return
+            if self._cfg.get("hotkey_show_at_mouse", False):
+                try:
+                    position = self._get_hotkey_window_position()
+                    if position is not None:
+                        self._window.move(*position)
+                except Exception:
+                    pass
+            self._visible = True
+            self._show_on_gui()
+            # 在锁内设置 _hotkey_session，避免 show 与 schedule_hide 之间的竞争窗口
             self._hotkey_session = True
 
     def schedule_hide(self):

--- a/src/webui.py
+++ b/src/webui.py
@@ -3365,6 +3365,7 @@ class WebUI:
             visible = self._visible
             if visible:
                 self._visible = False
+                self._hotkey_session = False
                 self._hide_on_gui()
                 return
             if self._cfg.get("hotkey_show_at_mouse", False):

--- a/src/webui.py
+++ b/src/webui.py
@@ -273,6 +273,16 @@ class JsApi:
         self._drag_origin = None
         self._drag_last_move = 0.0
 
+    def _dialog(self, kind, **kw):
+        """主窗口上下文打开文件对话框（owner 为主窗口，无需焦点恢复）"""
+        win = webview.windows[0] if webview.windows else None
+        if win is None:
+            return None
+        try:
+            return win.create_file_dialog(kind, **kw)
+        except Exception:
+            return None
+
     def search_memes(
         self, keyword="", tags=None, collection_id=None, offset=0, limit=200
     ):


### PR DESCRIPTION
对应提交：72a63d4、87efd19、8de2335（基于 #82 之后的增量）

## 背景

用户反馈两个独立的界面问题：

1. **设置页选择目录后窗口被主窗口覆盖**：在设置页（存储位置、QQNT 导入、微信导入、TG 导入、备份等）打开文件对话框选择目录/文件后，对话框关闭焦点回到主窗口，设置窗口失去激活被遮挡，用户需手动重新切回设置页
2. **高频热键触发卡死**：快速连续按全局热键（Ctrl+Alt+N）呼出/隐藏主窗口时，界面卡死无响应

## 设计决策（与需求方确认）

- **对话框 owner**：所有 `pick_*` / `import_*` / `export_logs` / `save_qq_zip` / `backup_pick_*` 的文件对话框统一改用设置窗口为 owner（fallback 主窗口），对话框关闭后自动恢复设置窗口前台焦点
- **热键去抖**：250ms 内重复触发直接返回，消除高频触发场景
- **状态锁**：三个窗口状态标志（`_visible`/`_pending_hide`/`_hotkey_session`）全部持锁读写，消除数据竞争
- **线程亲和**：`show()`/`hide()` 的窗口操作在非 GUI 线程时通过 `_run_on_gui(0, ...)` 调度回 GUI 主线程，避免跨线程操作 pywebview 窗口导致卡死

## 实现

| 文件 | 改动 |
|---|---|
| `src/webui.py` | `WebUI` 新增 `_window_state_lock`、`_last_toggle_ms` 去抖、`focus_settings_window()`；`show()`/`hide()`/`toggle_hotkey_safe()`/`schedule_hide()` 持锁 + 线程亲和调度；新增 `JsApi._dialog()`（主窗口上下文）和 `SettingsApi._dialog()`（设置窗口上下文 + 焦点恢复）；11 个对话框方法统一改用 `_dialog()` |

## 关键行为

- **对话框覆盖修复**：设置页所有对话框（存储位置、QQNT、微信、TG、备份、导入）关闭后设置窗口自动回到前台
- **热键去抖**：250ms 内连续按键不再重复执行 toggle
- **线程安全**：窗口状态标志全部持锁，`show()`/`hide()` 在非 GUI 线程时自动调度回 GUI 主线程
- **取消语义**：`schedule_hide` 的 `_process_pending_hide` 改为调 `self.hide()`，保持状态一致

## 验证

- `python -m pytest tests/`：281 passed, 1 skipped
- `ruff check src/` / `black --check src/`：通过
- 手动冒烟：设置页各导入向导选目录后设置窗口仍在前台；高频连按热键 10+ 次不卡死

## Sourcery 总结

修复设置对话框焦点问题和高频热键稳定性问题，同时确保窗口状态转换的线程安全。

错误修复：
- 防止设置页面中的文件对话框关闭后设置窗口被遮挡，通过恢复其前台焦点来解决。
- 通过防抖和同步窗口状态处理，防止快速重复按下全局热键导致界面冻结。
- 确保待处理的热键隐藏操作与窗口可见状态保持一致。

改进：
- 确保主窗口的显示、隐藏和热键切换具备线程安全性，并在需要时确保原生窗口操作在 GUI 线程上执行。
- 集中处理主窗口和设置窗口的文件对话框，并设置适当的窗口所有权，同时统一失败和取消时的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix settings dialog focus and high-frequency hotkey stability while making window state transitions thread-safe.

Bug Fixes:
- Prevent settings-page file dialogs from leaving the settings window obscured by restoring its foreground focus after dialogs close.
- Prevent rapid repeated global hotkey presses from freezing the interface through debouncing and synchronized window state handling.
- Keep pending hotkey hides consistent with the window visibility state.

Enhancements:
- Make main-window show, hide, and hotkey toggling thread-safe and ensure native window operations are performed on the GUI thread when required.
- Centralize file-dialog handling for the main and settings windows with appropriate window ownership and consistent failure/cancellation behavior.

</details>

<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 统一文件、目录选择及保存对话框体验。
  - 文件和目录对话框关闭后，可自动恢复设置窗口焦点。
  - 改善主窗口显示、隐藏及切换操作的稳定性。
  - 优化快捷键切换行为，提升窗口状态切换的可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->