### PR TITLE
fix: 删除标签下最后一张图后筛选卡死 + 悬空分组筛选兜底 + 空页自动回退

### DIFF
--- a/src/vue-src/App.vue
+++ b/src/vue-src/App.vue
@@ -457,7 +457,7 @@ async function onCtxAction(action: string) {
       break
     }
     case 'delete': {
-      if (await confirmAsk('删除表情包', '确定删除这个表情包吗？')) { await window.pywebview?.api?.delete_meme(t.memeId); search(); refreshCollections() }
+      if (await confirmAsk('删除表情包', '确定删除这个表情包吗？')) { await window.pywebview?.api?.delete_meme(t.memeId); search(); refreshCollections(); refreshTags() }
       break
     }
     case 'rename-collection': {

--- a/src/vue-src/composables/useMemes.ts
+++ b/src/vue-src/composables/useMemes.ts
@@ -57,9 +57,11 @@ export function useMemes() {
         api('search_memes', state.searchQuery, [...state.activeTags], state.activeCollection, offset, MEME_PAGE),
       ])
       if (gen !== searchGen) return
-      state.total = countResult || 0
+      // 桥接失败（null/非数组）时保留当前分页与结果，避免暂时性故障触发空页回退或清空网格
+      if (!Array.isArray(memesResult) || typeof countResult !== 'number') return
+      state.total = countResult
       state.pageCount = Math.max(1, Math.ceil(state.total / MEME_PAGE))
-      state.memes = memesResult || []
+      state.memes = memesResult
       // 删除等操作使当前页变空时回退到可用末页，避免停留在空页显示「没有表情包」
       if (!resetPage && state.memes.length === 0 && state.page > 1) {
         const target = Math.max(1, Math.min(state.page, state.pageCount))
@@ -67,9 +69,6 @@ export function useMemes() {
       }
     } catch (e) {
       if (gen !== searchGen) return
-      state.memes = []
-      state.total = 0
-      state.pageCount = 1
     } finally {
       if (gen === searchGen) state.loading = false
     }
@@ -97,7 +96,11 @@ export function useMemes() {
     search()
   }
   async function refreshTags() {
-    try { state.allTags = (await api('get_tags')) || [] } catch { state.allTags = [] }
+    let tags: string[] | null = null
+    try { tags = await api('get_tags') } catch { return }
+    // 桥接失败（null/非数组）时保留现有标签与筛选，避免暂时性故障清掉用户筛选
+    if (!Array.isArray(tags)) return
+    state.allTags = tags
     // 清理已不存在的激活标签（如删除标签下最后一张图后孤儿标签被清理），否则筛选永久卡死
     let pruned = false
     for (const t of [...state.activeTags]) {
@@ -106,7 +109,11 @@ export function useMemes() {
     if (pruned) await search()
   }
   async function refreshCollections() {
-    try { state.collections = (await api('get_collections')) || [] } catch { state.collections = [] }
+    let items: any[] | null = null
+    try { items = await api('get_collections') } catch { return }
+    // 桥接失败（null/非数组）时保留现有分组树与筛选，避免暂时性故障复位用户分组
+    if (!Array.isArray(items)) return
+    state.collections = items
     // 当前分组已被后端隐式删除（如同步 push 时 manifest 清理空分组）时复位到「全部」，避免筛选永久空显
     const ac = state.activeCollection
     if (ac && ac > 0 && !_collectionExists(state.collections, ac)) {

--- a/src/vue-src/composables/useMemes.ts
+++ b/src/vue-src/composables/useMemes.ts
@@ -60,6 +60,11 @@ export function useMemes() {
       state.total = countResult || 0
       state.pageCount = Math.max(1, Math.ceil(state.total / MEME_PAGE))
       state.memes = memesResult || []
+      // 删除等操作使当前页变空时回退到可用末页，避免停留在空页显示「没有表情包」
+      if (!resetPage && state.memes.length === 0 && state.page > 1) {
+        const target = Math.max(1, Math.min(state.page, state.pageCount))
+        if (target !== state.page) { state.page = target; return search(false) }
+      }
     } catch (e) {
       if (gen !== searchGen) return
       state.memes = []
@@ -100,7 +105,15 @@ export function useMemes() {
     }
     if (pruned) await search()
   }
-  async function refreshCollections() { try { state.collections = (await api('get_collections')) || [] } catch { state.collections = [] } }
+  async function refreshCollections() {
+    try { state.collections = (await api('get_collections')) || [] } catch { state.collections = [] }
+    // 当前分组已被后端隐式删除（如同步 push 时 manifest 清理空分组）时复位到「全部」，避免筛选永久空显
+    const ac = state.activeCollection
+    if (ac && ac > 0 && !_collectionExists(state.collections, ac)) {
+      state.activeCollection = null
+      await search()
+    }
+  }
   async function copyMeme(id: number): Promise<boolean> {
     const result = await api('copy_meme', id)
     return !!result?.ok
@@ -115,6 +128,14 @@ export function useMemes() {
   function setMemes(newMemes: Meme[]) { state.memes = newMemes }
 
   function selectAllVisible() { state.selectedIds = new Set(state.memes.map(m => m.id)) }
+
+  function _collectionExists(items: any[], id: number): boolean {
+    for (const c of items) {
+      if (c.id === id) return true
+      if (c.children && _collectionExists(c.children, id)) return true
+    }
+    return false
+  }
   function clearSelection() { state.selectedIds = new Set() }
 
   function canReorder(): boolean {

--- a/src/vue-src/composables/useMemes.ts
+++ b/src/vue-src/composables/useMemes.ts
@@ -91,7 +91,15 @@ export function useMemes() {
     else state.activeCollection = id
     search()
   }
-  async function refreshTags() { try { state.allTags = (await api('get_tags')) || [] } catch { state.allTags = [] } }
+  async function refreshTags() {
+    try { state.allTags = (await api('get_tags')) || [] } catch { state.allTags = [] }
+    // 清理已不存在的激活标签（如删除标签下最后一张图后孤儿标签被清理），否则筛选永久卡死
+    let pruned = false
+    for (const t of [...state.activeTags]) {
+      if (!state.allTags.includes(t)) { state.activeTags.delete(t); pruned = true }
+    }
+    if (pruned) await search()
+  }
   async function refreshCollections() { try { state.collections = (await api('get_collections')) || [] } catch { state.collections = [] } }
   async function copyMeme(id: number): Promise<boolean> {
     const result = await api('copy_meme', id)


### PR DESCRIPTION
## 问题

选中一个标签筛选后，删除该标签下唯一（或最后一张）表情包，界面显示「没有表情包」；刷新、重新选择左侧分组均无法恢复，只能重启软件。

## 根因

删除最后一张图后，后端 `_prune_orphan_tags` 会把该孤儿标签从数据库清理掉，但前端 `state.activeTags` 仍持有该标签名。之后所有查询（刷新、切分组、翻页）都带着这个已不存在的标签做筛选，永远返回空；且标签栏因标签已删除不再显示它，无法点击取消，形成死锁。

`refreshTags()` 此前只更新 `state.allTags`，从不清理 `activeTags` 中的失效项；右键单图删除路径甚至连 `refreshTags()` 都未调用。

## 修复

### 1. 标签筛选死锁（核心修复）

- `useMemes.ts` `refreshTags()`：拉取最新标签列表后，清理 `activeTags` 中已不存在的标签，若有清理则自动重新搜索。单点兜底，覆盖批量删除、单图改标签（`set_meme_tags`）、批量打标签等所有已调用 `refreshTags` 的路径
- `App.vue` 右键单图删除：补调 `refreshTags()`（原先只调 `search()` + `refreshCollections()`）

修复后行为：删除标签下最后一张图后，失效筛选被自动清除，界面立即恢复显示当前分组内容。

### 2. 悬空分组筛选（同款问题的同类排查）

按「前端持久筛选状态引用后端已失效实体 → 界面永久空显」模式全面排查后发现的缺口：

- `build_manifest()` 会自动删除空分组，在同步 push/pull、排序持久化、存储迁移等后端链路被调用。在设置窗口手动同步时，主窗口正浏览的空分组可能被静默删除，`activeCollection` 变成悬空引用且侧边栏已无该分组可点
- 修复：`refreshCollections()` 检测当前激活的正 ID 分组已不在最新分组树中时，复位到「全部」并重搜——与标签修复相同的单点兜底

### 3. 翻页停留空页（同症状，程度较轻）

在第 3 页批量删除本页全部表情后，`search(false)` 停在空页显示「没有表情包」，尽管前面页有数据（翻页可恢复）。修复：`search` 内部增加与 `goToPage` 一致的末页回退，当前页被删空时自动落到可用末页。

## 已确认有防护、无需改动的链路

- 批量移动后删除移空的源分组：已显式切换到父分组或未分类
- 右键删除分组/小分组：已先移出成员、删组并切换激活分组
- 单个「从分组移除」导致源分组变空被删：已处理激活态切换
- `selectedIds`：每次 `search()` 自动清空；对已删 id 的批量操作后端有过滤
- `searchQuery`：可随时手动清空，无后端依赖

## 影响范围

仅前端两个文件：`src/vue-src/App.vue`、`src/vue-src/composables/useMemes.ts`（已执行 `npx vite build` 更新 `dist/ohmymeme.js`），不涉及后端与数据库变更。用户拖拽自定义的分组排序、标签数据均不受影响。

## 验证

- `npx vite build` 构建通过
- `python -m pytest tests/`：281 passed, 1 skipped
- 复现路径验证：选中标签 → 删除该标签下唯一图 → 筛选自动清除、界面恢复正常，无需重启

## Sourcery 摘要

通过清除过时的筛选条件并恢复空结果页面，确保删除内容或后端清理后仍可正常浏览梗图。

错误修复：
- 防止删除某个标签下的最后一张梗图后，过时的标签筛选条件锁定界面。
- 活跃集合被删除后，通过重置为“所有项目”视图来恢复。
- 删除操作导致当前页面为空时，自动返回到最后一个可用页面。

改进：
- 集中处理刷新时对活跃标签和集合的验证，使前端筛选条件与后端状态保持同步。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

当删除操作或后端清理导致活动筛选条件失效，或当前页面为空时，确保表情包浏览功能可以恢复正常。

Bug 修复：
- 当后端移除已删除的标签时，清除过时的标签筛选条件；删除某个标签下的最后一个表情包后，恢复正常浏览。
- 当当前选中的集合被移除时，将浏览范围重置为所有集合，避免因残留的集合筛选条件导致结果为空。
- 当删除操作导致当前页面为空时，自动回退到最后一个可用页面。

增强功能：
- 当标签、集合或搜索请求返回无效或临时性的桥接响应时，保留现有结果和筛选条件。
- 在刷新期间集中验证当前活动的标签和集合，使前端筛选条件与后端状态保持同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep meme browsing recoverable when deletions or backend cleanup invalidate active filters or empty the current page.

Bug Fixes:
- Clear stale tag filters when deleted tags are removed from the backend, restoring normal browsing after the last meme under a tag is deleted.
- Reset browsing to all collections when the active collection is removed, preventing empty results from a dangling collection filter.
- Automatically fall back to the last available page when deletions leave the current page empty.

Enhancements:
- Preserve existing results and filters when tag, collection, or search requests return invalid or transient bridge responses.
- Centralize validation of active tags and collections during refreshes to keep frontend filters synchronized with backend state.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 删除表情包后，标签列表会同步刷新，确保页面信息保持最新。
  - 搜索结果为空且当前页码超出范围时，自动返回可用的最后一页。
  - 刷新标签或分组后，自动清理已不存在的筛选条件，并更新搜索结果。
  - 当前分组被删除后，自动切换至“全部”分组，避免显示异常。
  - 数据请求失败时保留当前分页、结果和筛选状态，避免页面被错误清空。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->